### PR TITLE
unowned self in Kitura-WebSocket sometimes referenced after being reclaimed

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -32,8 +32,10 @@ public class WebSocketConnection {
     weak var service: WebSocketService? {
         didSet {
             guard let service = service else { return }
-            DispatchQueue.global().async { [unowned self] in
-                service.connected(connection: self)
+            DispatchQueue.global().async { [weak self] in
+                if let strongSelf = self {
+                    service.connected(connection: strongSelf)
+                }
             }
         }
     }
@@ -168,8 +170,10 @@ public class WebSocketConnection {
             let reasonTosend = reasonToSendBack ?? reason
             closeConnection(reason: reasonTosend, description: description, hard: true)
             
-            DispatchQueue.global().async { [unowned self] in
-                self.service?.disconnected(connection: self, reason: reason)
+            DispatchQueue.global().async { [weak self] in
+                if let strongSelf = self {
+                    strongSelf.service?.disconnected(connection: strongSelf, reason: reason)
+                }
             }
         }
         else {


### PR DESCRIPTION
We are seeing crashes in Kitura-WebSocket unit tests because unowned self is sometimes being referenced after being reclaimed in a couple of places. We may need to change them to weak references instead.

See IBM-Swift/Kitura#988