### PR TITLE
Prevent the Connection.request field from being freed

### DIFF
--- a/Sources/KituraWebSocket/WSServerRequest.swift
+++ b/Sources/KituraWebSocket/WSServerRequest.swift
@@ -1,0 +1,109 @@
+/*
+ * Copyright IBM Corporation 2016-2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+import KituraNet
+
+/// An internal class used to retain information from the original request that
+/// was used to to create the WebSocket connection. The ServerRequest from KituraNet
+/// may get freed.
+class WSServerRequest: ServerRequest {
+    
+    /// The set of headers received with the incoming request
+    let headers = HeadersContainer()
+    
+    /// The URL from the request in string form
+    /// This contains just the path and query parameters starting with '/'
+    /// Use 'urlURL' for the full URL
+    @available(*, deprecated, message:
+    "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+    var urlString: String { return String(data: url, encoding: .utf8) ?? "" }
+    
+    /// The URL from the request in UTF-8 form
+    /// This contains just the path and query parameters starting with '/'
+    /// Use 'urlURL' for the full URL
+    let url: Data
+    
+    private var urlc: URLComponents?
+    
+    /// The URL from the request as URLComponents
+    /// URLComponents has a memory leak on linux as of swift 3.0.1. Use 'urlURL' instead
+    @available(*, deprecated, message:
+    "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")
+    public var urlComponents: URLComponents {
+        if let urlc = self.urlc {
+            return urlc
+        }
+        let urlc = URLComponents(url: self.urlURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+        self.urlc = urlc
+        return urlc
+    }
+    
+    /// The URL from the request
+    let urlURL: URL
+    
+    /// The IP address of the client
+    let remoteAddress: String
+    
+    /// Major version of HTTP of the request
+    var httpVersionMajor: UInt16? = 1
+    
+    /// Minor version of HTTP of the request
+    var httpVersionMinor: UInt16? = 1
+    
+    /// The HTTP Method specified in the request
+    var method: String = "GET"
+    
+    init(request: ServerRequest) {
+        url = request.url
+        urlURL = request.urlURL
+        remoteAddress = request.remoteAddress
+        
+        for (key, values) in request.headers {
+            headers.append(key, value: values)
+        }
+    }
+    
+    /// Read data from the body of the request
+    ///
+    /// - Parameter data: A Data struct to hold the data read in.
+    ///
+    /// - Throws: Socket.error if an error occurred while reading from the socket
+    /// - Returns: The number of bytes read
+    func read(into data: inout Data) throws -> Int {
+        return 0
+    }
+    
+    /// Read a string from the body of the request.
+    ///
+    /// - Throws: Socket.error if an error occurred while reading from the socket
+    /// - Returns: An Optional string
+    func readString() throws -> String? {
+        return nil
+    }
+    
+    
+    /// Read all of the data in the body of the request
+    ///
+    /// - Parameter data: A Data struct to hold the data read in.
+    ///
+    /// - Throws: Socket.error if an error occurred while reading from the socket
+    /// - Returns: The number of bytes read
+    func readAllData(into data: inout Data) throws -> Int {
+        return 0
+    }
+}

--- a/Sources/KituraWebSocket/WSServerRequest.swift
+++ b/Sources/KituraWebSocket/WSServerRequest.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corporation 2016-2017
+ * Copyright IBM Corporation 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import Foundation
 import KituraNet
 
 /// An internal class used to retain information from the original request that
-/// was used to to create the WebSocket connection. The ServerRequest from KituraNet
+/// was used to create the WebSocket connection. The ServerRequest from KituraNet
 /// may get freed.
 class WSServerRequest: ServerRequest {
     

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -71,7 +71,7 @@ public class WebSocketConnection {
     
     init(request: ServerRequest) {
         id = UUID().uuidString
-        self.request = request
+        self.request = WSServerRequest(request: request)
         buffer = NSMutableData(capacity: WebSocketConnection.bufferSize) ?? NSMutableData()
     }
     

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -31,6 +31,7 @@ class BasicTests: KituraTest {
             ("testGracefullClose", testGracefullClose),
             ("testPing", testPing),
             ("testPingWithText", testPingWithText),
+            ("testServerRequest", testServerRequest),
             ("testSuccessfullUpgrade", testSuccessfullUpgrade),
             ("testTextLongMessage", testTextLongMessage),
             ("testTextMediumMessage", testTextMediumMessage),
@@ -134,6 +135,24 @@ class BasicTests: KituraTest {
             self.performTest(framesToSend: [(true, self.opcodePing, pingPayload)],
                              expectedFrames: [(true, self.opcodePong, pingPayload)],
                              expectation: expectation)
+        }
+    }
+    
+    func testServerRequest() {
+        register(closeReason: .noReasonCodeSent, testServerRequest: true)
+        
+        performServerTest() { expectation in
+            guard let socket = self.sendUpgradeRequest(toPath: "/wstester", usingKey: self.secWebKey) else { return }
+            
+            _ = self.checkUpgradeResponse(from: socket, forKey: self.secWebKey, expectation: expectation)
+            
+            sleep(3)       // Wait a bit for the WebSocketService to test the ServerRequest
+            
+            // Close the socket abruptly. Need to wait to let the close percolate up on the other side
+            socket.close()
+            usleep(150)
+            
+            expectation.fulfill()
         }
     }
     

--- a/Tests/KituraWebSocketTests/KituraTest.swift
+++ b/Tests/KituraWebSocketTests/KituraTest.swift
@@ -96,8 +96,8 @@ class KituraTest: XCTestCase {
         expectation.fulfill()
     }
     
-    func register(closeReason: WebSocketCloseReasonCode) {
-        WebSocket.register(service: TestWebSocketService(closeReason: closeReason), onPath: "/wstester")
+    func register(closeReason: WebSocketCloseReasonCode, testServerRequest: Bool=false) {
+        WebSocket.register(service: TestWebSocketService(closeReason: closeReason, testServerRequest: testServerRequest), onPath: "/wstester")
     }
     
     func sendUpgradeRequest(forProtocolVersion: String?="13", toPath: String, usingKey: String?) -> Socket? {


### PR DESCRIPTION
Part of the Kitura-WebSocket Connection API is access to the ServerRequest that was to upgrade the original HTTP 1.1 connection into a WebSocket connection.

The original implementation simply saved a reference to the original ServerRequest from KituraNet. This is problematic as some of the underlying classes/structs of the KituraNet ServerRequest get released and/or reused causing problems. This was raised in IBM-Swift/Kitura-WebSocket#12.

This PR adds a class that is used to clone the KituraNet ServerRequest and is then used in the Kitura-WebSocket Connection API.

This has been unit tested on macOS and Linux with tests added to test the new ServerRequest implementation.