### PR TITLE
Improve code coverage and enable sending of messages in "connected event handler"

### DIFF
--- a/Sources/KituraWebSocket/WSSocketProcessor.swift
+++ b/Sources/KituraWebSocket/WSSocketProcessor.swift
@@ -25,7 +25,12 @@ import LoggerAPI
 class WSSocketProcessor: IncomingSocketProcessor {
     /// A back reference to the `IncomingSocketHandler` processing the socket that
     /// this `IncomingDataProcessor` is processing.
-    public weak var handler: IncomingSocketHandler?
+    public weak var handler: IncomingSocketHandler? {
+        didSet {
+            guard handler != nil else { return }
+            connection.fireConnected()
+        }
+    }
     
     /// The socket if idle will be kept alive until...
     public var keepAliveUntil: TimeInterval = 500.0

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -31,16 +31,7 @@ import KituraNet
 public class WebSocketConnection {
     weak var processor: WSSocketProcessor?
     
-    weak var service: WebSocketService? {
-        didSet {
-            guard let service = service else { return }
-            callbackQueue.async { [weak self] in
-                if let strongSelf = self {
-                    service.connected(connection: strongSelf)
-                }
-            }
-        }
-    }
+    weak var service: WebSocketService?
     
     private static let bufferSize = 2000
     private let buffer: NSMutableData
@@ -192,6 +183,16 @@ public class WebSocketConnection {
         }
         else {
             processor?.close()
+        }
+    }
+    
+    func fireConnected() {
+        guard let service = service else { return }
+        
+        callbackQueue.async { [weak self] in
+            if let strongSelf = self {
+                service.connected(connection: strongSelf)
+            }
         }
     }
     

--- a/Tests/KituraWebSocketTests/KituraTest.swift
+++ b/Tests/KituraWebSocketTests/KituraTest.swift
@@ -71,7 +71,7 @@ class KituraTest: XCTestCase {
                      expectedFrames: [(Bool, Int, NSData)], expectation: XCTestExpectation) {
         guard let socket = sendUpgradeRequest(toPath: "/wstester", usingKey: secWebKey) else { return }
         
-        let buffer = checkUpgradeResponse(from: socket, forKey: secWebKey, expectation: expectation)
+        let buffer = checkUpgradeResponse(from: socket, forKey: secWebKey)
         
         for frameToSend in framesToSend {
             let (finalToSend, opCodeToSend, payloadToSend) = frameToSend
@@ -96,8 +96,9 @@ class KituraTest: XCTestCase {
         expectation.fulfill()
     }
     
-    func register(closeReason: WebSocketCloseReasonCode, testServerRequest: Bool=false) {
-        WebSocket.register(service: TestWebSocketService(closeReason: closeReason, testServerRequest: testServerRequest), onPath: "/wstester")
+    func register(closeReason: WebSocketCloseReasonCode, testServerRequest: Bool=false, pingMessage: String?=nil) {
+        let service = TestWebSocketService(closeReason: closeReason, testServerRequest: testServerRequest, pingMessage: pingMessage)
+        WebSocket.register(service: service, onPath: "/wstester")
     }
     
     func sendUpgradeRequest(forProtocolVersion: String?="13", toPath: String, usingKey: String?) -> Socket? {
@@ -168,7 +169,7 @@ class KituraTest: XCTestCase {
         return (errorFlag ? nil : response, unparsedData)
     }
     
-    func checkUpgradeResponse(from: Socket, forKey: String, expectation: XCTestExpectation) -> NSMutableData {
+    func checkUpgradeResponse(from: Socket, forKey: String) -> NSMutableData {
         let (rawResponse, extraData) = self.processUpgradeResponse(socket: from)
         let buffer = extraData ?? NSMutableData()
         

--- a/Tests/KituraWebSocketTests/TestWebSocketService.swift
+++ b/Tests/KituraWebSocketTests/TestWebSocketService.swift
@@ -23,15 +23,26 @@ import KituraNet
 class TestWebSocketService: WebSocketService {
     var connectionId = ""
     let closeReason: WebSocketCloseReasonCode
+    let pingMessage: String?
     let testServerRequest: Bool
     
-    public init(closeReason: WebSocketCloseReasonCode, testServerRequest: Bool) {
+    public init(closeReason: WebSocketCloseReasonCode, testServerRequest: Bool, pingMessage: String?) {
         self.closeReason = closeReason
         self.testServerRequest = testServerRequest
+        self.pingMessage = pingMessage
     }
     
     public func connected(connection: WebSocketConnection) {
         connectionId = connection.id
+        
+        if let pingMessage = pingMessage {
+            if pingMessage.characters.count > 0 {
+                connection.ping(withMessage: pingMessage)
+            }
+            else {
+                connection.ping()
+            }
+        }
         
         if testServerRequest {
             performServerRequestTests(request: connection.request)


### PR DESCRIPTION
Add tests to Kitura-WebSocket to improve the code coverage.

Fix issue with the "connected event handler" (WebSocketService.connected) being invoked before the response was sent to the websocket upgrade request. This prevented "connected event handler" from sending messages to the client.