### PR TITLE
pass ping and rsv tests

### DIFF
--- a/Sources/KituraWebSocket/WSFrameParser.swift
+++ b/Sources/KituraWebSocket/WSFrameParser.swift
@@ -81,13 +81,13 @@ struct WSFrameParser {
     
     private mutating func parseOpCode(bytes: UnsafePointer<UInt8>, from: Int) -> (WebSocketError?, Int) {
         let byte = bytes[from]
-        // 0x.. is the hexidecimal representation of the bits you would like to check
+        // 0x.. is the hexadecimal representation of the bits you would like to check
         // e.g.0x0f is 15 which is 00001111 so rawOpCode is the last 4 digits
         
-        // Check RSV is equal to 0
+        // Check RSV (three reserved bits) is equal to 0
         let rsv = (byte & 0x70) >> 4
         guard rsv == 0 else {
-            return (.invalidRSV(rsv), 0)
+            return (.invalidOpCode(byte & 0x7F), 0)
         }
         frame.finalFrame = byte & 0x80 != 0
         let rawOpCode = byte & 0x0f

--- a/Sources/KituraWebSocket/WSFrameParser.swift
+++ b/Sources/KituraWebSocket/WSFrameParser.swift
@@ -81,8 +81,15 @@ struct WSFrameParser {
     
     private mutating func parseOpCode(bytes: UnsafePointer<UInt8>, from: Int) -> (WebSocketError?, Int) {
         let byte = bytes[from]
-        frame.finalFrame = byte & 0x80 != 0
+        // 0x.. is the hexidecimal representation of the bits you would like to check
+        // e.g.0x0f is 15 which is 00001111 so rawOpCode is the last 4 digits
         
+        // Check RSV is equal to 0
+        let rsv = (byte & 0x70) >> 4
+        guard rsv == 0 else {
+            return (.invalidRSV(rsv), 0)
+        }
+        frame.finalFrame = byte & 0x80 != 0
         let rawOpCode = byte & 0x0f
         if let opCode = WSFrame.FrameOpcode(rawValue: Int(rawOpCode)) {
             self.frame.opCode = opCode

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -263,7 +263,12 @@ public class WebSocketConnection {
             }
             
         case .ping:
-            sendMessage(withOpCode: .pong, payload: frame.payload.bytes, payloadLength: frame.payload.length)
+            if frame.payload.length < 126 {
+                sendMessage(withOpCode: .pong, payload: frame.payload.bytes, payloadLength: frame.payload.length)
+            } else {
+                connectionClosed(reason: .protocolError, description: "Control frames are only allowed to have payload up to and including 125 octets")
+                return
+            }
             
         case .pong:
             break

--- a/Sources/KituraWebSocket/WebSocketError.swift
+++ b/Sources/KituraWebSocket/WebSocketError.swift
@@ -19,6 +19,9 @@ import Foundation
 /// An error enum used when throwing errors within KituraWebSocket.
 public enum WebSocketError: Error {
     
+    /// An invalid RSV was received in a WebSocket frame
+    case invalidRSV(UInt8)
+    
     /// An invalid opcode was received in a WebSocket frame
     case invalidOpCode(UInt8)
     

--- a/Sources/KituraWebSocket/WebSocketError.swift
+++ b/Sources/KituraWebSocket/WebSocketError.swift
@@ -31,6 +31,8 @@ extension WebSocketError: CustomStringConvertible {
     /// Generate a printable version of this enum.
     public var description: String {
         switch self {
+        case .invalidRSV(let rsv):
+            return "Parsed a frame with an invalid RSV code of \(rsv)"
         case .invalidOpCode(let opCode):
             return "Parsed a frame with an invalid operation code of \(opCode)"
         case .unmaskedFrame:

--- a/Sources/KituraWebSocket/WebSocketError.swift
+++ b/Sources/KituraWebSocket/WebSocketError.swift
@@ -18,10 +18,7 @@ import Foundation
 
 /// An error enum used when throwing errors within KituraWebSocket.
 public enum WebSocketError: Error {
-    
-    /// An invalid RSV was received in a WebSocket frame
-    case invalidRSV(UInt8)
-    
+
     /// An invalid opcode was received in a WebSocket frame
     case invalidOpCode(UInt8)
     
@@ -34,8 +31,6 @@ extension WebSocketError: CustomStringConvertible {
     /// Generate a printable version of this enum.
     public var description: String {
         switch self {
-        case .invalidRSV(let rsv):
-            return "Parsed a frame with an invalid RSV code of \(rsv)"
         case .invalidOpCode(let opCode):
             return "Parsed a frame with an invalid operation code of \(opCode)"
         case .unmaskedFrame:

--- a/Sources/KituraWebSocket/WebSocketError.swift
+++ b/Sources/KituraWebSocket/WebSocketError.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// An error enum used when throwing errors within KituraWebSocket.
 public enum WebSocketError: Error {
-
+    
     /// An invalid opcode was received in a WebSocket frame
     case invalidOpCode(UInt8)
     

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -69,8 +69,9 @@ class ProtocolErrorTests: KituraTest {
         expectedPayload.append(part.bytes, length: part.length)
         
         performServerTest() { expectation in
-            let oversizedPayload = Data(repeatElement(0, count: 126))
-            self.performTest(framesToSend: [(true, self.opcodePing, oversizedPayload as NSData)],
+            let oversizedPayload = NSMutableData()
+            oversizedPayload.append(Data(repeatElement(0, count: 126)))
+            self.performTest(framesToSend: [(true, self.opcodePing, oversizedPayload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
         }

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -27,7 +27,7 @@ class ProtocolErrorTests: KituraTest {
             ("testBinaryAndTextFrames", testBinaryAndTextFrames),
             ("testPingWithOversizedPayload", testPingWithOversizedPayload),
             ("testInvalidOpCode", testInvalidOpCode),
-            //("testInvalidRSVCode", testInvalidRSVCode),
+            ("testInvalidRSVCode", testInvalidRSVCode),
             ("testJustContinuationFrame", testJustContinuationFrame),
             ("testJustFinalContinuationFrame", testJustFinalContinuationFrame),
             ("testTextAndBinaryFrames", testTextAndBinaryFrames),

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -27,6 +27,7 @@ class ProtocolErrorTests: KituraTest {
             ("testBinaryAndTextFrames", testBinaryAndTextFrames),
             ("testPingWithOversizedPayload", testPingWithOversizedPayload),
             ("testInvalidOpCode", testInvalidOpCode),
+            //("testInvalidRSVCode", testInvalidRSVCode),
             ("testJustContinuationFrame", testJustContinuationFrame),
             ("testJustFinalContinuationFrame", testJustFinalContinuationFrame),
             ("testTextAndBinaryFrames", testTextAndBinaryFrames),
@@ -95,26 +96,26 @@ class ProtocolErrorTests: KituraTest {
         }
     }
     
-    func testInvalidRSV() {
+    func testInvalidRSVCode() {
         register(closeReason: .protocolError)
-        
+
         performServerTest() { expectation in
-            
+
             var bytes = [0x00, 0x01]
             let payload = NSMutableData(bytes: &bytes, length: bytes.count)
-            
+
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
             expectedPayload.append(part.bytes, length: part.length)
-            part = self.payload(text: "Parsed a frame with an invalid operation code of 15")
+            part = self.payload(text: "Parsed a frame with an invalid operation code of 25")
             expectedPayload.append(part.bytes, length: part.length)
-            
-            self.performTest(framesToSend: [(true, 15, payload)],
+            // 25 becomes 0011001 which is a ping (op code 9) and rsv = 1
+            self.performTest(framesToSend: [(true, 25, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
         }
     }
-    
+
     func testJustContinuationFrame() {
         register(closeReason: .protocolError)
         


### PR DESCRIPTION
This pull request if to make our websockets server pass [Autobahn tests](https://github.com/crossbario/autobahn-testsuite). 

These changes make websockets pass:
 Case 2.5 (oversized ping)
 Case 3.* (Reserved bits are == 0)