### PR TITLE
fix: user defined close message

### DIFF
--- a/Sources/KituraWebSocket/WebSocketCloseReasonCode.swift
+++ b/Sources/KituraWebSocket/WebSocketCloseReasonCode.swift
@@ -50,11 +50,11 @@ public enum WebSocketCloseReasonCode {
     /// The server had an error with the request (1011)
     case serverError
     
-    /// This reson code is used to send application defined reason codes.
-    case userDefined(Int16)
+    /// This reason code is used to send application defined reason codes.
+    case userDefined(UInt16)
     
     /// Get the sixteen bit integer code for a WebSocketCloseReasonCode instance
-    public func code() -> Int16 {
+    public func code() -> UInt16 {
         switch self {
         case .closedAbnormally: return 1006
         case .extensionMissing: return 1010
@@ -72,7 +72,7 @@ public enum WebSocketCloseReasonCode {
     }
     
     /// Convert a sixteen bit WebSocket close frame reason code to a WebSocketCloseReasonCode instance 
-    public static func from(code reasonCode: Int16) -> WebSocketCloseReasonCode {
+    public static func from(code reasonCode: UInt16) -> WebSocketCloseReasonCode {
         switch reasonCode {
         case 1000: return .normal
         case 1001: return .goingAway

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -224,14 +224,14 @@ public class WebSocketConnection {
                 if frame.payload.length >= 2 {
                     let networkOrderedReasonCode = UnsafeRawPointer(frame.payload.bytes).assumingMemoryBound(to: UInt16.self)[0]
                 
-                    let reasonCodeUInt16: UInt16
+                    let hostOrderedReasonCode: UInt16
                     #if os(Linux)
-                        reasonCodeUInt16 = UInt16(Glibc.ntohs(networkOrderedReasonCode))
+                        hostOrderedReasonCode = UInt16(Glibc.ntohs(networkOrderedReasonCode))
                     #else
-                        reasonCodeUInt16 = UInt16(CFSwapInt16BigToHost(networkOrderedReasonCode))
+                        hostOrderedReasonCode = UInt16(CFSwapInt16BigToHost(networkOrderedReasonCode))
                     #endif
                     
-                    reasonCode = WebSocketCloseReasonCode.from(code: reasonCodeUInt16)                }
+                    reasonCode = WebSocketCloseReasonCode.from(code: hostOrderedReasonCode)                }
                 else {
                     reasonCode = .noReasonCodeSent
                 }

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -224,14 +224,14 @@ public class WebSocketConnection {
                 if frame.payload.length >= 2 {
                     let networkOrderedReasonCode = UnsafeRawPointer(frame.payload.bytes).assumingMemoryBound(to: UInt16.self)[0]
                 
-                    let reasonCodeInt16: Int16
+                    let reasonCodeUInt16: UInt16
                     #if os(Linux)
-                        reasonCodeInt16 = Int16(Glibc.ntohs(networkOrderedReasonCode))
+                        reasonCodeUInt16 = UInt16(Glibc.ntohs(networkOrderedReasonCode))
                     #else
-                        reasonCodeInt16 = Int16(CFSwapInt16BigToHost(networkOrderedReasonCode))
+                        reasonCodeUInt16 = UInt16(CFSwapInt16BigToHost(networkOrderedReasonCode))
                     #endif
                     
-                    reasonCode = WebSocketCloseReasonCode.from(code: reasonCodeInt16)                }
+                    reasonCode = WebSocketCloseReasonCode.from(code: reasonCodeUInt16)                }
                 else {
                     reasonCode = .noReasonCodeSent
                 }

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -309,4 +309,17 @@ class BasicTests: KituraTest {
                              expectation: expectation)
         }
     }
+    
+    func testUserDefinedCloseMessage() {
+        register(closeReason: .userDefined(65535))
+        
+        performServerTest() { expectation in
+            
+            let textPayload = self.payload(text: "Testing, testing 1,2,3")
+            
+            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                             expectedFrames: [(true, self.opcodeText, textPayload)],
+                             expectation: expectation)
+        }
+    }
 }

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -316,10 +316,11 @@ class BasicTests: KituraTest {
         
         performServerTest() { expectation in
             
-            let textPayload = self.payload(text: "Testing, testing 1,2,3")
+            let closePayload = self.payload(closeReasonCode: .userDefined(65535))
+            let returnPayload = self.payload(closeReasonCode: .normal)
             
-            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
-                             expectedFrames: [(true, self.opcodeText, textPayload)],
+            self.performTest(framesToSend: [(true, self.opcodeClose, closePayload)],
+                             expectedFrames: [(true, self.opcodeClose, returnPayload)],
                              expectation: expectation)
         }
     }

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -38,7 +38,8 @@ class BasicTests: KituraTest {
             ("testSuccessfulUpgrade", testSuccessfulUpgrade),
             ("testTextLongMessage", testTextLongMessage),
             ("testTextMediumMessage", testTextMediumMessage),
-            ("testTextShortMessage", testTextShortMessage)
+            ("testTextShortMessage", testTextShortMessage),
+            ("testUserDefinedCloseMessage", testUserDefinedCloseMessage)
         ]
     }
     


### PR DESCRIPTION
Fixed a bug caused when i user sent a large code reason code.

This was caused by the server using Int16 instead of UInt16.

A test for user defined large input has been added and now passed.