### PR TITLE
No fragmenting control frames

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -268,7 +268,7 @@ public class WebSocketConnection {
                 return
             }
             guard frame.finalFrame else {
-                connectionClosed(reason: .protocolError, description: "Control frames cannot be fragmented")
+                connectionClosed(reason: .protocolError, description: "Control frames must not be fragmented")
                 return
             }
             sendMessage(withOpCode: .pong, payload: frame.payload.bytes, payloadLength: frame.payload.length)

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -263,12 +263,15 @@ public class WebSocketConnection {
             }
             
         case .ping:
-            if frame.payload.length < 126 {
-                sendMessage(withOpCode: .pong, payload: frame.payload.bytes, payloadLength: frame.payload.length)
-            } else {
+            guard frame.payload.length < 126 else {
                 connectionClosed(reason: .protocolError, description: "Control frames are only allowed to have payload up to and including 125 octets")
                 return
             }
+            guard frame.finalFrame else {
+                connectionClosed(reason: .protocolError, description: "Control frames cannot be fragmented")
+                return
+            }
+            sendMessage(withOpCode: .pong, payload: frame.payload.bytes, payloadLength: frame.payload.length)
             
         case .pong:
             break

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -26,6 +26,7 @@ class ProtocolErrorTests: KituraTest {
         return [
             ("testBinaryAndTextFrames", testBinaryAndTextFrames),
             ("testPingWithOversizedPayload", testPingWithOversizedPayload),
+            ("testFragmentedPing", testFragmentedPing),
             ("testInvalidOpCode", testInvalidOpCode),
             ("testInvalidRSVCode", testInvalidRSVCode),
             ("testJustContinuationFrame", testJustContinuationFrame),

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -90,7 +90,7 @@ class ProtocolErrorTests: KituraTest {
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .protocolError)
             expectedPayload.append(part.bytes, length: part.length)
-            part = self.payload(text: "Control frames cannot be fragmented")
+            part = self.payload(text: "Control frames must not be fragmented")
             expectedPayload.append(part.bytes, length: part.length)
             
             let pingPayload = self.payload(text: "Testing, testing 1,2,3")


### PR DESCRIPTION
By the [websockets protocol](https://tools.ietf.org/html/rfc6455#section-5.4) control frames such as ping, close and pong cannot be fragmented. 

This means we should close if we receive a control frame which has a continuation.

Since pong and close will close already we have only changed ping.

This now passes autobahn test 5.1 and a test to check this has been added.