### PR TITLE
Fix: Resolve deprecation warnings for swift 4.1

### DIFF
--- a/Sources/KituraWebSocket/WSFrame.swift
+++ b/Sources/KituraWebSocket/WSFrame.swift
@@ -50,7 +50,7 @@ struct WSFrame {
                 payloadLengthUInt16 = CFSwapInt16HostToBig(tempPayloadLengh)
             #endif
             let asBytes = UnsafeMutablePointer(&payloadLengthUInt16)
-            (UnsafeMutableRawPointer(mutating: bytes)+length+1).copyBytes(from: asBytes, count: 2)
+            (UnsafeMutableRawPointer(mutating: bytes)+length+1).copyMemory(from: asBytes, byteCount: 2)
             length += 3
         } else {
             bytes[1] = 127
@@ -62,7 +62,7 @@ struct WSFrame {
                 payloadLengthUInt32 = CFSwapInt32HostToBig(tempPayloadLengh)
             #endif
             let asBytes = UnsafeMutablePointer(&payloadLengthUInt32)
-            (UnsafeMutableRawPointer(mutating: bytes)+length+5).copyBytes(from: asBytes, count: 4)
+            (UnsafeMutableRawPointer(mutating: bytes)+length+5).copyMemory(from: asBytes, byteCount: 4)
             length += 9
         }
         buffer.append(bytes, length: length)

--- a/Sources/KituraWebSocket/WSFrame.swift
+++ b/Sources/KituraWebSocket/WSFrame.swift
@@ -50,7 +50,11 @@ struct WSFrame {
                 payloadLengthUInt16 = CFSwapInt16HostToBig(tempPayloadLengh)
             #endif
             let asBytes = UnsafeMutablePointer(&payloadLengthUInt16)
-            (UnsafeMutableRawPointer(mutating: bytes)+length+1).copyMemory(from: asBytes, byteCount: 2)
+            #if swift(>=4.1)
+                (UnsafeMutableRawPointer(mutating: bytes)+length+1).copyMemory(from: asBytes, byteCount: 2)
+            #else
+                (UnsafeMutableRawPointer(mutating: bytes)+length+1).copyBytes(from: asBytes, count: 2)
+            #endif
             length += 3
         } else {
             bytes[1] = 127
@@ -62,7 +66,11 @@ struct WSFrame {
                 payloadLengthUInt32 = CFSwapInt32HostToBig(tempPayloadLengh)
             #endif
             let asBytes = UnsafeMutablePointer(&payloadLengthUInt32)
-            (UnsafeMutableRawPointer(mutating: bytes)+length+5).copyMemory(from: asBytes, byteCount: 4)
+            #if swift(>=4.1)
+                (UnsafeMutableRawPointer(mutating: bytes)+length+5).copyMemory(from: asBytes, byteCount: 4)
+            #else
+                (UnsafeMutableRawPointer(mutating: bytes)+length+5).copyBytes(from: asBytes, count: 4)
+            #endif
             length += 9
         }
         buffer.append(bytes, length: length)

--- a/Sources/KituraWebSocket/WSFrameParser.swift
+++ b/Sources/KituraWebSocket/WSFrameParser.swift
@@ -140,7 +140,11 @@ struct WSFrameParser {
         
         if bytesConsumed > 0 {
             if length - from - bytesConsumed >= maskSize {
-                UnsafeMutableRawPointer(mutating: mask).copyMemory(from: bytes+from+bytesConsumed, byteCount: maskSize)
+                #if swift(>=4.1)
+                    UnsafeMutableRawPointer(mutating: mask).copyMemory(from: bytes+from+bytesConsumed, byteCount: maskSize)
+                #else
+                    UnsafeMutableRawPointer(mutating: mask).copyBytes(from: bytes+from+bytesConsumed, count: maskSize)
+                #endif
                 bytesConsumed += maskSize
             }
             else {

--- a/Sources/KituraWebSocket/WSFrameParser.swift
+++ b/Sources/KituraWebSocket/WSFrameParser.swift
@@ -140,7 +140,7 @@ struct WSFrameParser {
         
         if bytesConsumed > 0 {
             if length - from - bytesConsumed >= maskSize {
-                UnsafeMutableRawPointer(mutating: mask).copyBytes(from: bytes+from+bytesConsumed, count: maskSize)
+                UnsafeMutableRawPointer(mutating: mask).copyMemory(from: bytes+from+bytesConsumed, byteCount: maskSize)
                 bytesConsumed += maskSize
             }
             else {


### PR DESCRIPTION
Replaces 'copyBytes(from:count:)' with 'copyMemory(from:byteCount:)' to silence swift 4.1 deprecation warnings.