### PR TITLE
close on invalid UTF-8

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -308,7 +308,7 @@ public class WebSocketConnection {
             }
         }
         else {
-            // Error converting to String
+            closeConnection(reason: .invalidDataContents, description: "Failed to convert received payload to UTF-8 String", hard: true)
         }
         from.length -= 1
     }

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -185,6 +185,25 @@ class ProtocolErrorTests: KituraTest {
         }
     }
     
+    func testInvalidUTF() {
+        register(closeReason: .noReasonCodeSent)
+        
+        performServerTest() { expectation in
+            let testString = "Testing, 1,2,3"
+            let textPayload = testString.data(using: String.Encoding.utf16)!
+            
+            let expectedPayload = NSMutableData()
+            var part = self.payload(closeReasonCode: .invalidDataContents)
+            expectedPayload.append(part.bytes, length: part.length)
+            part = self.payload(text: "Failed to convert received payload to UTF-8 String")
+            expectedPayload.append(part.bytes, length: part.length)
+            
+            self.performTest(framesToSend: [(true, self.opcodeText, textPayload as NSData)],
+                             expectedFrames: [(true, self.opcodeClose, expectedPayload)],
+                             expectation: expectation)
+        }
+    }
+    
     func testTextAndBinaryFrames() {
         register(closeReason: .protocolError)
         

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -31,6 +31,7 @@ class ProtocolErrorTests: KituraTest {
             ("testInvalidRSVCode", testInvalidRSVCode),
             ("testJustContinuationFrame", testJustContinuationFrame),
             ("testJustFinalContinuationFrame", testJustFinalContinuationFrame),
+            ("testInvalidUTF", testInvalidUTF),
             ("testTextAndBinaryFrames", testTextAndBinaryFrames),
             ("testUnmaskedFrame", testUnmaskedFrame)
         ]

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -191,7 +191,9 @@ class ProtocolErrorTests: KituraTest {
         
         performServerTest() { expectation in
             let testString = "Testing, 1,2,3"
-            let textPayload = testString.data(using: String.Encoding.utf16)!
+            let dataPayload = testString.data(using: String.Encoding.utf16)!
+            let payload = NSMutableData()
+            payload.append(dataPayload)
             
             let expectedPayload = NSMutableData()
             var part = self.payload(closeReasonCode: .invalidDataContents)
@@ -199,7 +201,7 @@ class ProtocolErrorTests: KituraTest {
             part = self.payload(text: "Failed to convert received payload to UTF-8 String")
             expectedPayload.append(part.bytes, length: part.length)
             
-            self.performTest(framesToSend: [(true, self.opcodeText, textPayload as NSData)],
+            self.performTest(framesToSend: [(true, self.opcodeText, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
                              expectation: expectation)
         }


### PR DESCRIPTION
This pull request makes the websocket server close the connection on receiving invalid UTF-8 and return the error message:
Failed to convert received payload to UTF-8 String

A new test has been added which sends invalid utf-8 and expects to receive this error code. 