### PR TITLE
Bad close codes

### DIFF
--- a/Sources/KituraWebSocket/WebSocketCloseReasonCode.swift
+++ b/Sources/KituraWebSocket/WebSocketCloseReasonCode.swift
@@ -84,7 +84,7 @@ public enum WebSocketCloseReasonCode {
         case 1010: return .extensionMissing
         case 1011: return .serverError
         default:
-            if(reasonCode < 3000) {
+            if reasonCode < 3000 {
                 return .protocolError
             } else {
                 return .userDefined(reasonCode)

--- a/Sources/KituraWebSocket/WebSocketCloseReasonCode.swift
+++ b/Sources/KituraWebSocket/WebSocketCloseReasonCode.swift
@@ -78,15 +78,17 @@ public enum WebSocketCloseReasonCode {
         case 1001: return .goingAway
         case 1002: return .protocolError
         case 1003: return .invalidDataType
-        case 1005: return .noReasonCodeSent
-        case 1006: return .closedAbnormally
         case 1007: return .invalidDataContents
         case 1008: return .policyViolation
         case 1009: return .messageTooLarge
         case 1010: return .extensionMissing
         case 1011: return .serverError
         default:
-            return .userDefined(reasonCode)
+            if(reasonCode < 3000) {
+                return .protocolError
+            } else {
+                return .userDefined(reasonCode)
+            }
         }
     }
 }

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -225,9 +225,9 @@ public class WebSocketConnection {
                     let networkOrderedReasonCode = UnsafeRawPointer(frame.payload.bytes).assumingMemoryBound(to: UInt16.self)[0]
                     let hostOrderedReasonCode: UInt16
                     #if os(Linux)
-                    hostOrderedReasonCode = UInt16(Glibc.ntohs(networkOrderedReasonCode))
+                        hostOrderedReasonCode = UInt16(Glibc.ntohs(networkOrderedReasonCode))
                     #else
-                    hostOrderedReasonCode = UInt16(CFSwapInt16BigToHost(networkOrderedReasonCode))
+                        hostOrderedReasonCode = UInt16(CFSwapInt16BigToHost(networkOrderedReasonCode))
                     #endif
                     reasonCode = WebSocketCloseReasonCode.from(code: hostOrderedReasonCode)
                 } else if frame.payload.length == 0 {

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -172,7 +172,6 @@ public class WebSocketConnection {
     func connectionClosed(reason: WebSocketCloseReasonCode, description: String? = nil, reasonToSendBack: WebSocketCloseReasonCode? = nil) {
         if active {
             let reasonTosend = reasonToSendBack ?? reason
-            print("reasonTosend \(reasonTosend)")
             closeConnection(reason: reasonTosend, description: description, hard: true)
             
             callbackQueue.async { [weak self] in

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -221,7 +221,7 @@ public class WebSocketConnection {
         case .close:
             if active {
                 let reasonCode: WebSocketCloseReasonCode
-                if frame.payload.length >= 2 && frame.payload.length <= 125 {
+                if frame.payload.length >= 2 && frame.payload.length < 126 {
                     let networkOrderedReasonCode = UnsafeRawPointer(frame.payload.bytes).assumingMemoryBound(to: UInt16.self)[0]
                     let hostOrderedReasonCode: UInt16
                     #if os(Linux)
@@ -233,7 +233,8 @@ public class WebSocketConnection {
                 } else if frame.payload.length == 0 {
                     reasonCode = .normal
                 } else {
-                    reasonCode = .protocolError
+                    connectionClosed(reason: .protocolError, description: "Close frames, which contain a payload, must be between 2 an 125 octets inclusive")
+                    return
                 }
                 connectionClosed(reason: reasonCode)
             }

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -233,7 +233,7 @@ public class WebSocketConnection {
                 } else if frame.payload.length == 0 {
                     reasonCode = .normal
                 } else {
-                    connectionClosed(reason: .protocolError, description: "Close frames, which contain a payload, must be between 2 an 125 octets inclusive")
+                    connectionClosed(reason: .protocolError, description: "Close frames, which contain a payload, must be between 2 and 125 octets inclusive")
                     return
                 }
                 connectionClosed(reason: reasonCode)

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -312,12 +312,12 @@ class BasicTests: KituraTest {
     }
     
     func testUserDefinedCloseMessage() {
-        register(closeReason: .userDefined(5000))
+        register(closeReason: .userDefined(65535))
         
         performServerTest() { expectation in
             
-            let closePayload = self.payload(closeReasonCode: .userDefined(5000))
-            let returnPayload = self.payload(closeReasonCode: .userDefined(5000))
+            let closePayload = self.payload(closeReasonCode: .userDefined(65535))
+            let returnPayload = self.payload(closeReasonCode: .userDefined(65535))
             
             self.performTest(framesToSend: [(true, self.opcodeClose, closePayload)],
                              expectedFrames: [(true, self.opcodeClose, returnPayload)],

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -312,12 +312,12 @@ class BasicTests: KituraTest {
     }
     
     func testUserDefinedCloseMessage() {
-        register(closeReason: .userDefined(65535))
+        register(closeReason: .userDefined(5000))
         
         performServerTest() { expectation in
             
-            let closePayload = self.payload(closeReasonCode: .userDefined(65535))
-            let returnPayload = self.payload(closeReasonCode: .normal)
+            let closePayload = self.payload(closeReasonCode: .userDefined(5000))
+            let returnPayload = self.payload(closeReasonCode: .userDefined(5000))
             
             self.performTest(framesToSend: [(true, self.opcodeClose, closePayload)],
                              expectedFrames: [(true, self.opcodeClose, returnPayload)],

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -29,6 +29,7 @@ class ProtocolErrorTests: KituraTest {
             ("testFragmentedPing", testFragmentedPing),
             ("testInvalidOpCode", testInvalidOpCode),
             ("testInvalidRSVCode", testInvalidRSVCode),
+            ("testInvalidUserCloseCode", testInvalidUserCloseCode),
             ("testJustContinuationFrame", testJustContinuationFrame),
             ("testJustFinalContinuationFrame", testJustFinalContinuationFrame),
             ("testInvalidUTF", testInvalidUTF),
@@ -140,6 +141,19 @@ class ProtocolErrorTests: KituraTest {
             // 25 becomes 0011001 which is a ping (op code 9) and rsv = 1
             self.performTest(framesToSend: [(true, 25, payload)],
                              expectedFrames: [(true, self.opcodeClose, expectedPayload)],
+                             expectation: expectation)
+        }
+    }
+    
+    func testInvalidUserCloseCode() {
+        register(closeReason: .protocolError)
+        
+        performServerTest() { expectation in
+            
+            let closePayload = self.payload(closeReasonCode: .userDefined(2999))
+            let returnPayload = self.payload(closeReasonCode: .protocolError)
+            self.performTest(framesToSend: [(true, self.opcodeClose, closePayload)],
+                             expectedFrames: [(true, self.opcodeClose, returnPayload)],
                              expectation: expectation)
         }
     }

--- a/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
+++ b/Tests/KituraWebSocketTests/ProtocolErrorTests.swift
@@ -165,7 +165,7 @@ class ProtocolErrorTests: KituraTest {
         let expectedPayload = NSMutableData()
         var part = self.payload(closeReasonCode: .protocolError)
         expectedPayload.append(part.bytes, length: part.length)
-        part = self.payload(text: "Close frames, which contain a payload, must be between 2 an 125 octets inclusive")
+        part = self.payload(text: "Close frames, which contain a payload, must be between 2 and 125 octets inclusive")
         expectedPayload.append(part.bytes, length: part.length)
         
         performServerTest() { expectation in


### PR DESCRIPTION
Pull request to make our web sockets pass autobahn tests 7.* regarding close codes.

reserved user close codes (1005, 1006) and undefined codes < 3000 will now return a protocol error. 

Close payloads can now not be longer than 125 bytes or equal to 1 byte as defined by the protocol

The close code provided by the server is now used to be sent back instead of just calculating it and then sending back .normal regardless.

Two Tests have been added and an existing test ha been change to check for the desired behavior.