### PR TITLE
accept null utf char

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -297,20 +297,15 @@ public class WebSocketConnection {
     }
     
     private func fireReceivedString(from: NSMutableData) {
-        var zero: CChar = 0
-        from.append(&zero, length: 1)
-        let bytes = from.bytes.bindMemory(to: CChar.self, capacity: 1)
-        if let text = String(cString: bytes, encoding: .utf8) {
-            callbackQueue.async { [weak self] in
-                if let strongSelf = self {
-                    strongSelf.service?.received(message: text, from: strongSelf)
-                }
+        guard let text = String(data: from as Data, encoding: .utf8) else {
+            closeConnection(reason: .invalidDataContents, description: "Failed to convert received payload to UTF-8 String", hard: true)
+            return
+        }
+        callbackQueue.async { [weak self] in
+            if let strongSelf = self {
+                strongSelf.service?.received(message: text, from: strongSelf)
             }
         }
-        else {
-            closeConnection(reason: .invalidDataContents, description: "Failed to convert received payload to UTF-8 String", hard: true)
-        }
-        from.length -= 1
     }
     
     private func sendMessage(withOpCode: WSFrame.FrameOpcode, payload: UnsafeRawPointer?, payloadLength: Int) {

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -297,7 +297,7 @@ public class WebSocketConnection {
     }
     
     private func fireReceivedString(from: NSMutableData) {
-        guard let text = String(data: from as Data, encoding: .utf8) else {
+        guard let text = String(data: Data(referencing: from), encoding: .utf8) else {
             closeConnection(reason: .invalidDataContents, description: "Failed to convert received payload to UTF-8 String", hard: true)
             return
         }

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -311,6 +311,19 @@ class BasicTests: KituraTest {
         }
     }
     
+    func testNullCharacter() {
+        register(closeReason: .noReasonCodeSent)
+        
+        performServerTest() { expectation in
+            
+            let textPayload = self.payload(text: "\u{0}")
+            
+            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                             expectedFrames: [(true, self.opcodeText, textPayload)],
+                             expectation: expectation)
+        }
+    }
+    
     func testUserDefinedCloseMessage() {
         register(closeReason: .userDefined(65535))
         


### PR DESCRIPTION
Replaced the system for converting data to string.
Previously data had a null terminator added on the end and was converted to a pointer which was then used to read as a string up to the null terminator. If the user sent a null terminator in their string then their message would only be read up to that point.

Now the Data is converted straight to a utf8 string and sent on.

Test added to check this behavior.