### PR TITLE
Add a lastFrameReceivedAt timestamp so that dead connections can be detected

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -47,7 +47,9 @@ public class WebSocketConnection {
     private let message = NSMutableData()
     
     private var active = true
-    
+
+    private(set) public var lastFrameReceivedAt: Date
+
     enum MessageStates {
         case binary, text, unknown
     }
@@ -63,6 +65,7 @@ public class WebSocketConnection {
     init(request: ServerRequest) {
         self.request = WSServerRequest(request: request)
         buffer = NSMutableData(capacity: WebSocketConnection.bufferSize) ?? NSMutableData()
+        lastFrameReceivedAt = Date()
     }
     
     /// Close a WebSocket connection by sending a close control command to the client optionally
@@ -196,7 +199,8 @@ public class WebSocketConnection {
     }
     
     func received(frame: WSFrame) {
-        
+        lastFrameReceivedAt = Date()
+
         switch frame.opCode {
         case .binary:
             guard messageState == .unknown else {


### PR DESCRIPTION
This feature allows a server to detect when a websocket has gone stale. It is to fix #24.

Here is an example of how my server uses this API to cleanup old connections:

```
    func _connectionKeepAliveAndCleanup() {
        let pingInterval: TimeInterval = 60

        for connection in connections {
            connection.ping()
            if connection.lastFrameReceivedAt.numberOfSecondsOld > 2 * pingInterval {
                connection.close(reason: .normal, description: nil)
                self.disconnected(connection: connection, reason: .normal)
            }
        }

        readWriteQueue.asyncAfter(deadline: DispatchTime.now() + pingInterval) {
            self._connectionKeepAliveAndCleanup()
        }
    }
```