### PR TITLE
[websocket-nio]Close connection for invalid operation code

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -188,8 +188,11 @@ extension WebSocketConnection: ChannelInboundHandler {
             case .pong:
                 break
  
-            default:
-                break
+            case .unknownNonControl(let code):
+                closeConnection(reason: .protocolError, description: "Parsed frame with an invalid operation code of \(code)", hard: true)
+
+            case .unknownControl(let code):
+                closeConnection(reason: .protocolError, description: "Parsed frame with an invalid operation code of \(code)", hard: true)
 
         } 
     }


### PR DESCRIPTION
The connection must be dropped/closed with error code 1002 for an invalid operation code.