### PR TITLE
Handle NIOWebSocketErrors

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -218,6 +218,22 @@ extension WebSocketConnection: ChannelInboundHandler {
         } 
     }
 
+    public func errorCaught(ctx: ChannelHandlerContext, error: Error) {
+        guard let error = error as? NIOWebSocketError else {
+            fatalError("Can only handle NIOWebSocketErrors")
+        }
+
+        switch error {
+            case .multiByteControlFrameLength:
+                connectionClosed(reason: .protocolError, description: "Control frames must have a payload length of 125 bytes or less")
+
+            case .fragmentedControlFrame:
+                connectionClosed(reason: .protocolError, description: "Control frames must not be fragmented")
+
+            default: break
+        }
+    }
+
     private func unmaskedData(frame: WebSocketFrame) -> ByteBuffer {
        var frameData = frame.data
        if let maskingKey = frame.maskKey {

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -224,13 +224,13 @@ extension WebSocketConnection: ChannelInboundHandler {
         }
 
         switch error {
-            case .multiByteControlFrameLength:
-                connectionClosed(reason: .protocolError, description: "Control frames must have a payload length of 125 bytes or less")
+        case .multiByteControlFrameLength:
+            connectionClosed(reason: .protocolError, description: "Control frames must have a payload length of 125 bytes or less")
 
-            case .fragmentedControlFrame:
-                connectionClosed(reason: .protocolError, description: "Control frames must not be fragmented")
+        case .fragmentedControlFrame:
+            connectionClosed(reason: .protocolError, description: "Control frames must not be fragmented")
 
-            default: break
+        default: break
         }
     }
 


### PR DESCRIPTION
[https://tools.ietf.org/html/rfc6455#section-5.5](url) specifies `All control frames MUST have a payload length of 125 bytes or less and MUST NOT be fragmented. `

For such control frames, errors are thrown by NIO websocket module and hence we must handle these errors.