### PR TITLE
Fix: make extension to WebSocketService public

### DIFF
--- a/Sources/KituraWebSocket/WebSocketService.swift
+++ b/Sources/KituraWebSocket/WebSocketService.swift
@@ -54,7 +54,7 @@ public protocol WebSocketService: class {
     var connectionTimeout: Int? { get }
 }
 
-extension WebSocketService {
+public extension WebSocketService {
     /// Default computed value for `connectionTimeout` that returns `nil`.
     var connectionTimeout: Int? {
         return nil


### PR DESCRIPTION
The extension to WebSocketService with default implementation for connectionTimeout was internal meaning that when a user implemented this protocol they had to implement the change themselves. 

This pr makes the extension public.