### PR TITLE
[websocket-nio]Fix for empty buffers

### DIFF
--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -177,8 +177,9 @@ extension WebSocketConnection: ChannelInboundHandler {
                     return
                 }
 
+                message?.write(buffer: &data)
                 guard var message = message else { return }
-                message.write(buffer: &data)
+
                 if frame.fin {
                     switch messageState {
                         case .binary:


### PR DESCRIPTION
The buffer data is lost when the frames are sent as fragments. This is because the data that are read are written back to local buffer which loses its scope and results in loss of data

```
guard var message = message else { return }		                 
message.write(buffer: &data)
```

