### PR TITLE
[websocket-nio]Fix SwiftLint errors and warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "Kitura-WebSocket",
-            targets: ["KituraWebSocket"]),
+            targets: ["KituraWebSocket"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -40,6 +40,6 @@ let package = Package(
             dependencies: ["KituraNet", "Cryptor"]),
         .testTarget(
             name: "KituraWebSocketTests",
-            dependencies: ["KituraWebSocket"]),
+            dependencies: ["KituraWebSocket"])
     ]
 )

--- a/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
+++ b/Sources/KituraWebSocket/WSConnectionUpgradeFactory.swift
@@ -20,7 +20,7 @@ import NIO
 import NIOHTTP1
 
 public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
-    private var registry = Dictionary<String, WebSocketService>()
+    private var registry: [String: WebSocketService] = [:]
 
     public let name = "websocket"
 
@@ -42,8 +42,7 @@ public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
         let path: String
         if onPath.hasPrefix("/") {
             path = onPath
-        }
-        else {
+        } else {
             path = "/" + onPath
         }
         registry[path] = service
@@ -53,8 +52,7 @@ public class WSConnectionUpgradeFactory: ProtocolHandlerFactory {
         let path: String
         if thePath.hasPrefix("/") {
             path = thePath
-        }
-        else {
+        } else {
             path = "/" + thePath
         }
         registry.removeValue(forKey: path)

--- a/Sources/KituraWebSocket/WSServerRequest.swift
+++ b/Sources/KituraWebSocket/WSServerRequest.swift
@@ -21,22 +21,22 @@ import KituraNet
 /// was used to create the WebSocket connection. The ServerRequest from KituraNet
 /// may get freed.
 class WSServerRequest: ServerRequest {
-    
+
     /// The set of headers received with the incoming request
     let headers = HeadersContainer()
-    
+
     /// The URL from the request in string form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
     "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     var urlString: String { return String(data: url, encoding: .utf8) ?? "" }
-    
+
     /// The URL from the request in UTF-8 form
     /// This contains just the path and query parameters starting with '/'
     /// Use 'urlURL' for the full URL
     let url: Data
-    
+
     /// The URL from the request
     let urlURL: URL
 
@@ -45,16 +45,16 @@ class WSServerRequest: ServerRequest {
 
     /// The IP address of the client
     let remoteAddress: String
-    
+
     /// Major version of HTTP of the request
     var httpVersionMajor: UInt16? = 1
-    
+
     /// Minor version of HTTP of the request
     var httpVersionMinor: UInt16? = 1
-    
+
     /// The HTTP Method specified in the request
     var method: String = "GET"
-    
+
     init(request: ServerRequest) {
         for (key, values) in request.headers {
             headers.append(key, value: values)
@@ -66,7 +66,7 @@ class WSServerRequest: ServerRequest {
 
         remoteAddress = request.remoteAddress
     }
-    
+
     /// Read data from the body of the request
     ///
     /// - Parameter data: A Data struct to hold the data read in.
@@ -76,7 +76,7 @@ class WSServerRequest: ServerRequest {
     func read(into data: inout Data) throws -> Int {
         return 0
     }
-    
+
     /// Read a string from the body of the request.
     ///
     /// - Throws: Socket.error if an error occurred while reading from the socket
@@ -84,8 +84,7 @@ class WSServerRequest: ServerRequest {
     func readString() throws -> String? {
         return nil
     }
-    
-    
+
     /// Read all of the data in the body of the request
     ///
     /// - Parameter data: A Data struct to hold the data read in.
@@ -96,4 +95,3 @@ class WSServerRequest: ServerRequest {
         return 0
     }
 }
-

--- a/Sources/KituraWebSocket/WebSocket.swift
+++ b/Sources/KituraWebSocket/WebSocket.swift
@@ -28,7 +28,7 @@ public class WebSocket {
     public static func register(service: WebSocketService, onPath path: String) {
         factory.register(service: service, onPath: path.lowercased())
     }
-    
+
     /// Unregister a `WebSocketService` for a specific path
     ///
     /// - Parameter path: The path on which the `WebSocketService` being unregistered,

--- a/Sources/KituraWebSocket/WebSocketCloseReasonCode.swift
+++ b/Sources/KituraWebSocket/WebSocketCloseReasonCode.swift
@@ -19,40 +19,40 @@
 public enum WebSocketCloseReasonCode {
     /// Closed abnormally (1006)
     case closedAbnormally
-    
+
     /// An extension was missing that was required (1010)
     case extensionMissing
-    
+
     /// Server is going away (1001)
     case goingAway
-    
+
     /// Data within a message was invalid (1007)
     case invalidDataContents
-    
+
     /// Message was of the incorrect type (binary/text) (1003)
     case invalidDataType
-    
+
     /// Message was too large (1009)
     case messageTooLarge
-    
+
     /// Closed normally (1000)
     case normal
-    
+
     /// No reason code sent with the close request (1005)
     case noReasonCodeSent
-    
+
     /// A policy violation occurred (1008)
     case policyViolation
-    
+
     /// A protocol error occurred (1002)
     case protocolError
-    
+
     /// The server had an error with the request (1011)
     case serverError
-    
+
     /// This reason code is used to send application defined reason codes.
     case userDefined(UInt16)
-    
+
     /// Get the sixteen bit integer code for a WebSocketCloseReasonCode instance
     public func code() -> UInt16 {
         switch self {
@@ -70,7 +70,7 @@ public enum WebSocketCloseReasonCode {
         case .userDefined(let userCode): return userCode
         }
     }
-    
+
     /// Convert a sixteen bit WebSocket close frame reason code to a WebSocketCloseReasonCode instance 
     public static func from(code reasonCode: UInt16) -> WebSocketCloseReasonCode {
         switch reasonCode {

--- a/Sources/KituraWebSocket/WebSocketError.swift
+++ b/Sources/KituraWebSocket/WebSocketError.swift
@@ -18,14 +18,13 @@ import Foundation
 
 /// An error enum used when throwing errors within KituraWebSocket.
 public enum WebSocketError: Error {
-    
+
     /// An invalid opcode was received in a WebSocket frame
     case invalidOpCode(UInt8)
-    
+
     /// A frame was received that had an unmasked payload
     case unmaskedFrame
 }
-
 
 extension WebSocketError: CustomStringConvertible {
     /// Generate a printable version of this enum.

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -39,14 +39,14 @@ class BasicTests: KituraTest {
             ("testTextShortMessage", testTextShortMessage),
             ("testNullCharacter", testNullCharacter),
             ("testUserDefinedCloseCode", testUserDefinedCloseCode),
-            ("testUserCloseMessage", testUserCloseMessage),
+            ("testUserCloseMessage", testUserCloseMessage)
         ]
     }
 
     func testBinaryLongMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
             let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
@@ -64,7 +64,7 @@ class BasicTests: KituraTest {
     func testBinaryMediumMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
             let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
@@ -81,7 +81,7 @@ class BasicTests: KituraTest {
     func testBinaryShortMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
             let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
@@ -95,7 +95,7 @@ class BasicTests: KituraTest {
     func testGracefullClose() {
         register(closeReason: .normal)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let sendPayload = self.payload(closeReasonCode: .normal)
             self.performTest(framesToSend: [(true, self.opcodeClose, sendPayload)],
                              expectedFrames: [(true, self.opcodeClose, sendPayload)],
@@ -106,7 +106,7 @@ class BasicTests: KituraTest {
     func testPing() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let pingPayload = NSData()
 
@@ -119,7 +119,7 @@ class BasicTests: KituraTest {
     func testPingWithText() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let pingPayload = self.payload(text: "Testing, testing 1,2,3")
 
@@ -132,7 +132,7 @@ class BasicTests: KituraTest {
     func testServerRequest() {
         register(closeReason: .noReasonCodeSent, testServerRequest: true)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let connected = DispatchSemaphore(value: 0)
             guard let _ = self.sendUpgradeRequest(toPath: self.servicePath, usingKey: self.secWebKey, semaphore: connected) else { return }
             connected.wait()
@@ -146,7 +146,7 @@ class BasicTests: KituraTest {
     func testSuccessfulRemove() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let upgraded = DispatchSemaphore(value: 0)
             guard let _ = self.sendUpgradeRequest(toPath: self.servicePath, usingKey: self.secWebKey, semaphore: upgraded) else { return }
             upgraded.wait()
@@ -166,8 +166,7 @@ class BasicTests: KituraTest {
             guard let _ = self.sendUpgradeRequest(toPath: self.servicePath, usingKey: self.secWebKey, semaphore: upgraded) else { return }
             upgraded.wait()
             expectation.fulfill()
-        },
-        { expectation in
+        }, { expectation in
             let upgraded = DispatchSemaphore(value: 0)
             WebSocket.unregister(path: self.servicePathNoSlash)
             self.register(onPath: self.servicePathNoSlash, closeReason: .noReasonCodeSent)
@@ -177,12 +176,10 @@ class BasicTests: KituraTest {
         })
     }
 
-
-
     func testTextLongMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var text = "Testing, testing 1, 2, 3."
             repeat {
@@ -199,7 +196,7 @@ class BasicTests: KituraTest {
     func testTextMediumMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var text = ""
             repeat {
@@ -216,7 +213,7 @@ class BasicTests: KituraTest {
     func testTextShortMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let textPayload = self.payload(text: "Testing, testing 1,2,3")
 
@@ -229,7 +226,7 @@ class BasicTests: KituraTest {
     func testUserDefinedCloseCode() {
         register(closeReason: .userDefined(65535))
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let closePayload = self.payload(closeReasonCode: .userDefined(65535))
             let returnPayload = self.payload(closeReasonCode: .userDefined(65535))
@@ -243,7 +240,7 @@ class BasicTests: KituraTest {
     func testUserCloseMessage() {
         register(closeReason: .normal)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let testString = "Testing, 1,2,3"
             let dataPayload = testString.data(using: String.Encoding.utf8)!
             let payload = NSMutableData()
@@ -260,7 +257,7 @@ class BasicTests: KituraTest {
     func testNullCharacter() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let textPayload = self.payload(text: "\u{00}")
 

--- a/Tests/KituraWebSocketTests/ComplexTests.swift
+++ b/Tests/KituraWebSocketTests/ComplexTests.swift
@@ -36,7 +36,7 @@ class ComplexTests: KituraTest {
     func testBinaryShortAndMediumFrames() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
 
@@ -60,7 +60,7 @@ class ComplexTests: KituraTest {
     func testBinaryTwoShortFrames() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
 
@@ -78,7 +78,7 @@ class ComplexTests: KituraTest {
     func testPingBetweenBinaryFrames() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
 
@@ -100,7 +100,7 @@ class ComplexTests: KituraTest {
     func testPingBetweenTextFrames() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let text = "Testing, testing 1, 2, 3. "
 
@@ -121,7 +121,7 @@ class ComplexTests: KituraTest {
     func testTextShortAndMediumFrames() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let shortText = "Testing, testing 1, 2, 3. "
             let shortTextPayload = self.payload(text: shortText)
@@ -143,7 +143,7 @@ class ComplexTests: KituraTest {
     func testTextTwoShortFrames() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let text = "Testing, testing 1, 2, 3. "
 

--- a/Tests/KituraWebSocketTests/KituraTest+Frames.swift
+++ b/Tests/KituraWebSocketTests/KituraTest+Frames.swift
@@ -54,7 +54,7 @@ extension KituraTest {
         let result = NSMutableData()
 
         let utf8Length = text.lengthOfBytes(using: .utf8)
-        var utf8: [CChar] = Array<CChar>(repeating: 0, count: utf8Length + 10) // A little bit of padding
+        var utf8: [CChar] = [CChar](repeating: 0, count: utf8Length + 10) // A little bit of padding
         guard text.getCString(&utf8, maxLength: utf8Length + 10, encoding: .utf8)  else {
             return result
         }
@@ -100,15 +100,14 @@ extension KituraTest {
             } else {
                 _ = channel.write(buffer)
             }
-        }
-        catch {
+        } catch {
             XCTFail("Failed to send a frame. Error=\(error)")
         }
     }
 
     private func createFrameHeader(final: Bool, withOpcode: Int, withMasking: Bool, payloadLength: Int, channel: Channel) -> ByteBuffer {
         var buffer = channel.allocator.buffer(capacity: 8)
-        var bytes: [UInt8] = [(final ? 0x80 : 0x00) | UInt8(withOpcode), 0, 0,0,0,0,0,0,0,0]
+        var bytes: [UInt8] = [(final ? 0x80 : 0x00) | UInt8(withOpcode), 0, 0, 0, 0, 0, 0, 0, 0, 0]
         var length = 1
 
         if payloadLength < 126 {

--- a/Tests/KituraWebSocketTests/KituraTest.swift
+++ b/Tests/KituraWebSocketTests/KituraTest.swift
@@ -50,7 +50,7 @@ class KituraTest: XCTestCase {
 
     let httpResponseDecoder = HTTPResponseDecoder()
 
-    var httpHandler: HTTPResponseHandler? = nil
+    var httpHandler: HTTPResponseHandler?
 
     func performServerTest(line: Int = #line,
                            asyncTasks: (XCTestExpectation) -> Void...) {
@@ -63,7 +63,7 @@ class KituraTest: XCTestCase {
 
             for (index, asyncTask) in asyncTasks.enumerated() {
                 let expectation = self.expectation(line: line, index: index)
-                requestQueue.async() {
+                requestQueue.async {
                     asyncTask(expectation)
                 }
             }
@@ -73,8 +73,7 @@ class KituraTest: XCTestCase {
                 server.stop()
                 XCTAssertNil(error)
             }
-        }
-        catch {
+        } catch {
             XCTFail("Test failed. Error=\(error)")
         }
     }
@@ -119,7 +118,7 @@ class KituraTest: XCTestCase {
 
         do {
             let channel = try clientBootstrap.connect(host: "localhost", port: 8080).wait()
-            var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor:1), method: HTTPMethod.method(from: "GET"), uri: toPath)
+            var request = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: HTTPMethod.method(from: "GET"), uri: toPath)
             var headers = HTTPHeaders()
             headers.add(name: "Host", value: "localhost:8080")
             headers.add(name: "Upgrade", value: "websocket")

--- a/Tests/KituraWebSocketTests/PrintLogger.swift
+++ b/Tests/KituraWebSocketTests/PrintLogger.swift
@@ -48,7 +48,7 @@ public class PrintLogger: Logger {
             return
         }
 
-        let color : TerminalColor
+        let color: TerminalColor
         switch type {
         case .warning:
             color = .yellow

--- a/Tests/KituraWebSocketTests/ProtocolError.swift
+++ b/Tests/KituraWebSocketTests/ProtocolError.swift
@@ -36,14 +36,14 @@ class ProtocolErrorTests: KituraTest {
             ("testInvalidUTF", testInvalidUTF),
             ("testInvalidUTFCloseMessage", testInvalidUTFCloseMessage),
             ("testTextAndBinaryFrames", testTextAndBinaryFrames),
-            ("testUnmaskedFrame", testUnmaskedFrame),
+            ("testUnmaskedFrame", testUnmaskedFrame)
         ]
     }
 
     func testBinaryAndTextFrames() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
 
@@ -73,7 +73,7 @@ class ProtocolErrorTests: KituraTest {
         part = self.payload(text: "Control frames are only allowed to have payload up to and including 125 octets")
         expectedPayload.append(part.bytes, length: part.length)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let oversizedPayload = NSMutableData()
             oversizedPayload.append(Data(repeatElement(0, count: 126)))
             self.performTest(framesToSend: [(true, self.opcodePing, oversizedPayload)],
@@ -85,7 +85,7 @@ class ProtocolErrorTests: KituraTest {
     func testFragmentedPing() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let text = "Testing, testing 1, 2, 3. "
 
@@ -110,7 +110,7 @@ class ProtocolErrorTests: KituraTest {
     func testInvalidOpCode() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01]
             let payload = NSMutableData(bytes: &bytes, length: bytes.count)
@@ -130,7 +130,7 @@ class ProtocolErrorTests: KituraTest {
     func testInvalidRSVCode() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01]
             let payload = NSMutableData(bytes: &bytes, length: bytes.count)
@@ -150,7 +150,7 @@ class ProtocolErrorTests: KituraTest {
     func testInvalidUserCloseCode() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let closePayload = self.payload(closeReasonCode: .userDefined(2999))
             let returnPayload = self.payload(closeReasonCode: .protocolError)
@@ -169,7 +169,7 @@ class ProtocolErrorTests: KituraTest {
         part = self.payload(text: "Control frames are only allowed to have payload up to and including 125 octets")
         expectedPayload.append(part.bytes, length: part.length)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let oversizedPayload = NSMutableData()
             oversizedPayload.append(Data(repeatElement(0, count: 126)))
             self.performTest(framesToSend: [(true, self.opcodeClose, oversizedPayload)],
@@ -181,7 +181,7 @@ class ProtocolErrorTests: KituraTest {
     func testJustContinuationFrame() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
 
@@ -202,7 +202,7 @@ class ProtocolErrorTests: KituraTest {
     func testJustFinalContinuationFrame() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
 
@@ -223,7 +223,7 @@ class ProtocolErrorTests: KituraTest {
     func testInvalidUTF() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let testString = "Testing, 1,2,3"
             let dataPayload = testString.data(using: String.Encoding.utf16)!
             let payload = NSMutableData()
@@ -244,7 +244,7 @@ class ProtocolErrorTests: KituraTest {
     func testInvalidUTFCloseMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let testString = "Testing, 1,2,3"
             let dataPayload = testString.data(using: String.Encoding.utf16)!
             let payload = NSMutableData()
@@ -267,7 +267,7 @@ class ProtocolErrorTests: KituraTest {
     func testTextAndBinaryFrames() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             let textPayload = self.payload(text: "testing 1 2 3")
             var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
@@ -289,7 +289,7 @@ class ProtocolErrorTests: KituraTest {
     func testUnmaskedFrame() {
         register(closeReason: .protocolError)
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
 
             var bytes = [0x00, 0x01]
             let payload = NSMutableData(bytes: &bytes, length: bytes.count)

--- a/Tests/KituraWebSocketTests/TestWebSocketService.swift
+++ b/Tests/KituraWebSocketTests/TestWebSocketService.swift
@@ -38,8 +38,7 @@ class TestWebSocketService: WebSocketService {
         if let pingMessage = pingMessage {
             if pingMessage.count > 0 {
                 connection.ping(withMessage: pingMessage)
-            }
-            else {
+            } else {
                 connection.ping()
             }
         }
@@ -72,8 +71,7 @@ class TestWebSocketService: WebSocketService {
             XCTAssertEqual(count, 0, "Read of body into a Data should have returned 0, it returned \(count)")
             count = try request.readAllData(into: &body)
             XCTAssertEqual(count, 0, "Read of entire body into a Data should have returned 0, it returned \(count)")
-        }
-        catch {
+        } catch {
             XCTFail("Failed to read from the body. Error=\(error)")
         }
     }
@@ -92,11 +90,9 @@ class TestWebSocketService: WebSocketService {
 
         if message == "close" {
             from.close(reason: .goingAway, description: "Going away...")
-        }
-        else if message == "drop" {
+        } else if message == "drop" {
             from.drop(reason: .policyViolation, description: "Droping...")
-        }
-        else if message == "ping" {
+        } else if message == "ping" {
             from.ping(withMessage: "Hello")
         }
     }

--- a/Tests/KituraWebSocketTests/UpgradeErrors.swift
+++ b/Tests/KituraWebSocketTests/UpgradeErrors.swift
@@ -33,7 +33,7 @@ class UpgradeErrors: KituraTest {
     func testNoSecWebSocketKey() {
         WebSocket.factory.clear()
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let upgradeFailed = DispatchSemaphore(value: 0)
             let message = "Sec-WebSocket-Key header missing in the upgrade request"
             guard let _ = self.sendUpgradeRequest(forProtocolVersion: "13", toPath: "/testing123", usingKey: nil, semaphore: upgradeFailed,
@@ -42,7 +42,6 @@ class UpgradeErrors: KituraTest {
             expectation.fulfill()
         }
     }
-
 
     func testNoSecWebSocketVersion() {
         WebSocket.factory.clear()
@@ -53,8 +52,7 @@ class UpgradeErrors: KituraTest {
             guard let _ = self.sendUpgradeRequest(forProtocolVersion: nil, toPath: "/testing123", usingKey: self.secWebKey, semaphore: upgradeFailed, errorMessage: message) else { return }
             upgradeFailed.wait()
             expectation.fulfill()
-        },
-        { expectation in
+        }, { expectation in
             let upgradeFailed = DispatchSemaphore(value: 0)
             let message = "Only WebSocket protocol version 13 is supported"
             guard let _ = self.sendUpgradeRequest(forProtocolVersion: "12", toPath: "/testing123", usingKey: self.secWebKey, semaphore: upgradeFailed, errorMessage: message) else { return }
@@ -66,7 +64,7 @@ class UpgradeErrors: KituraTest {
     func testNoService() {
         WebSocket.factory.clear()
 
-        performServerTest() { expectation in
+        performServerTest { expectation in
             let upgradeFailed = DispatchSemaphore(value: 0)
             let errorMessage = "No service has been registered for the path /testing123"
             guard let _ = self.sendUpgradeRequest(forProtocolVersion: "13", toPath: "/testing123", usingKey: self.secWebKey, semaphore: upgradeFailed, errorMessage: errorMessage) else { return }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -25,7 +25,7 @@ import Glibc
             guard c > 1 else { return }
 
             srand(UInt32(time(nil)))
-            for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
+            for (firstUnshuffled, unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
                 let d: Int = numericCast(random() % numericCast(unshuffledCount))
                 guard d != 0 else { continue }
                 let i = index(firstUnshuffled, offsetBy: d)
@@ -40,7 +40,7 @@ import Glibc
             guard c > 1 else { return }
 
             srand(UInt32(time(nil)))
-            for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
+            for (firstUnshuffled, unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
                 let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
                 guard d != 0 else { continue }
                 let i = index(firstUnshuffled, offsetBy: d)


### PR DESCRIPTION
This PR enforces Swift style and conventions based on https://github.com/realm/SwiftLint and violations for following rules has been fixed.

Closing Brace Spacing
Closure Spacing
Colon
Control Statement
Empty Parentheses with Trailing Closure
Empty Enum Arguments
Switch and Case Statement Alignment
Trailing Closure
Trailing Comma
Trailing Semicolon
Trailing Whitespace
Vertical Whitespace

Rules Ref: https://github.com/realm/SwiftLint/blob/master/Rules.md