### PR TITLE
Add websocket compression using permessage-deflate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .build
 build
 .vagrant
-Package*
+Package.resolved
 *.pkg
 Kitura-WebSocket.xcodeproj
 *.DS_Store

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**
@@ -31,17 +31,11 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", .branch("master")),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
+        .package(url: "https://github.com/IBM-Swift/CZlib", from: "0.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .systemLibrary(
-            name: "CZlib",
-            pkgConfig: "libz",
-            providers: [
-                .apt(["libz-dev"])
-            ]
-        ),
         .target(
             name: "KituraWebSocket",
             dependencies: ["CZlib", "KituraNet", "Cryptor"]),

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**
@@ -31,17 +31,11 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", .branch("master")),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
+        .package(url: "https://github.com/IBM-Swift/CZlib", from: "0.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .systemLibrary(
-            name: "CZlib",
-            pkgConfig: "libz",
-            providers: [
-                .apt(["libz-dev"])
-            ]
-        ),
         .target(
             name: "KituraWebSocket",
             dependencies: ["CZlib", "KituraNet", "Cryptor"]),

--- a/Sources/CZlib/module.modulemap
+++ b/Sources/CZlib/module.modulemap
@@ -1,0 +1,21 @@
+/**
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+ 
+ module CZlib {
+    header "shim.h"
+    link "z"
+    export *
+ }

--- a/Sources/CZlib/shim.h
+++ b/Sources/CZlib/shim.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+ 
+ 
+ #ifndef zlib_shim_h 
+ #define zlib_shim_h
+
+ #import <stdio.h>
+ #import <zlib.h>
+ 
+ #endif

--- a/Sources/KituraWebSocket/PermessageDeflate.swift
+++ b/Sources/KituraWebSocket/PermessageDeflate.swift
@@ -1,0 +1,89 @@
+/*
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIO
+
+// An extension that implements WebSocket compression through the permessage-deflate algorithm
+// RFC 7692: https://tools.ietf.org/html/rfc7692
+
+class PermessageDeflate: WebSocketProtocolExtension {
+
+    // Returns the deflater and inflater, to be subsequently added to the channel pipeline
+    func handlers(header: String) -> [ChannelHandler] {
+        guard header.hasPrefix("permessage-deflate") else { return [] }
+        var deflaterMaxWindowBits: Int32 = 15
+        var inflaterMaxWindowBits: Int32 = 15
+        var clientNoContextTakeover = false
+        let serverNoContextTakeover = false //TODO: `let` for now, needs to be a `var` when we start handling this parameter
+
+        // Four parameters to handle:
+        // * server_max_window_bits: the LZ77 sliding window size used by the server for compression
+        // * client_max_window_bits: the LZ77 sliding window size used by the server for decompression
+        // * server_no_context_takeover: prevent the server from using context-takeover
+        // * client_no_context_takeover: prevent the client from using context-takeover
+        for parameter in header.components(separatedBy: "; ") {
+            // If we receieved a valid value for server_max_window_bits, configure the deflater to use it
+            if parameter.hasPrefix("server_max_window_bits") {
+                let maxWindowBits = parameter.components(separatedBy: "=")
+                guard maxWindowBits.count == 2 else { continue }
+                if let mwBits = Int32(maxWindowBits[1]) {
+                    if mwBits >= 8 && mwBits <= 15 {
+                        deflaterMaxWindowBits = mwBits
+                    }
+                }
+            }
+
+            // If we receieved a valid value for server_max_window_bits, configure the inflater to use it
+            if parameter.hasPrefix("client_max_window_bits") {
+                let maxWindowBits = parameter.components(separatedBy: "=")
+                guard maxWindowBits.count == 2 else { continue }
+                if let mwBits = Int32(maxWindowBits[1]) {
+                    if mwBits >= 8 && mwBits <= 15  {
+                        inflaterMaxWindowBits = mwBits
+                    }
+                }
+            }
+
+            //TODO: If server_no_context_takeover was received, do we create new inflater/deflater objects?
+            if parameter == "client_no_context_takeover" {
+                clientNoContextTakeover = true
+            }
+        }
+
+        return [PermessageDeflateCompressor(maxWindowBits: deflaterMaxWindowBits, noContextTakeOver: serverNoContextTakeover),
+                   PermessageDeflateDecompressor(maxWindowBits: inflaterMaxWindowBits, noContextTakeOver: clientNoContextTakeover)]
+    }
+
+    // Comprehend the Sec-WebSocket-Extensions request header and build a response header
+    // In this context, the specification is not really very strict.
+    func negotiate(header: String) -> String {
+        var response = "permessage-deflate"
+
+        // This shouldn't be really possible. We reached here only because the header was used to fetch the PerMessageDeflate implementation.
+        guard header.hasPrefix("permessage-deflate") else { return response }
+
+        for parameter in header.components(separatedBy: "; ") {
+            if parameter.hasPrefix("client_max_window_bits") {
+                response.append("; client_max_window_bits")
+            }
+
+            if parameter == "client_no_context_takeover" {
+                response.append("; \(parameter)")
+            }
+        }
+        return response
+    }
+}

--- a/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
+++ b/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
@@ -1,0 +1,176 @@
+/*
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIO
+import NIOWebSocket
+import CZlib
+
+// Implementation of a deflater using zlib. This ChannelOutboundHandler acts like an interceptor, consuming original frames written by
+// WebSocketConnection, compressing the payload and writing the new frames with a compressed payload onto the channel.
+
+// Some of the code here is borrowed from swift-nio: https://github.com/apple/swift-nio/blob/master/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+class PermessageDeflateCompressor : ChannelOutboundHandler {
+    typealias OutboundIn = WebSocketFrame 
+    typealias OutboundOut = WebSocketFrame 
+
+    init(maxWindowBits: Int32 = 15, noContextTakeOver: Bool = false) {
+        self.maxWindowBits = maxWindowBits
+        self.noContextTakeOver = noContextTakeOver
+    }
+
+    var noContextTakeOver: Bool
+
+    // The default LZ77 window value; 15
+    var maxWindowBits = MAX_WBITS
+
+    // A buffer that accumulates payload data across multiple frames
+    var payload: ByteBuffer?
+
+    private var messageType: WebSocketOpcode?
+
+    // The zlib stream
+    private var stream: z_stream = z_stream()
+
+    // PermessageDeflateCompressor is an outbound handler, this function gets called when a frame is written to the channel by WebSocketConnection.
+    func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        var frame = unwrapOutboundIn(data)
+
+        // If this is a control frame, do not attempt compression.
+        guard frame.opcode == .text || frame.opcode == .binary || frame.opcode == .continuation else {
+             ctx.writeAndFlush(self.wrapOutboundOut(frame)).whenComplete {
+                 promise?.succeed(result: ())
+             }
+             return
+        }
+
+        // If this is a continuation frame, have the frame data appended to `payload`, else set payload to frame data.
+        if frame.opcode == .continuation {
+            self.payload?.write(buffer: &frame.data)
+        } else {
+            self.payload = frame.data
+            self.messageType = frame.opcode
+        }
+
+        // If the current frame isn't the final frame or if payload is empty, there's nothing to do.
+        guard frame.fin, let payload = payload else { return }
+
+        // Compress the payload
+        let deflatedPayload = deflatePayload(in: payload, allocator: ctx.channel.allocator)
+
+        // Create a new frame with the compressed payload, the rsv1 bit must be set to indicate compression
+        let deflatedFrame = WebSocketFrame(fin: frame.fin, rsv1: true, opcode: self.messageType!, maskKey: frame.maskKey, data: deflatedPayload)
+
+        // Write the new frame onto the pipeline
+        _ = ctx.writeAndFlush(self.wrapOutboundOut(deflatedFrame))
+    }
+
+    func deflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator, dropFourTrailingOctets: Bool = false) -> ByteBuffer {
+        // Initialize the deflater as per https://www.zlib.net/zlib_how.html
+        stream.zalloc = nil 
+        stream.zfree = nil 
+        stream.opaque = nil 
+
+        let rc = deflateInit2_(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, self.maxWindowBits, 8,
+                     Z_DEFAULT_STRATEGY, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
+        precondition(rc == Z_OK, "Unexpected return from zlib init: \(rc)")
+
+        defer {
+            // Deinitialize the deflater before returning
+            deflateEnd(&stream)
+        }
+
+        // Deflate/compress the payload
+        return compressPayload(in: buffer, allocator: allocator, flag: Z_SYNC_FLUSH, dropFourTrailingOctets: dropFourTrailingOctets)
+    }
+
+    private func compressPayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator, flag: Int32, dropFourTrailingOctets: Bool = false) -> ByteBuffer {
+        var inputBuffer = buffer
+        guard inputBuffer.readableBytes > 0 else {
+            //TODO: Log an error message
+            return inputBuffer
+        }
+
+        // Allocate an output buffer, with a size hint equal to the input (there's no other derivable value for this)
+        let bufferSize = Int(deflateBound(&stream, UInt(inputBuffer.readableBytes)))
+        var outputBuffer = allocator.buffer(capacity: bufferSize)
+
+        // Compress the payload
+        stream._deflate(from: &inputBuffer, to: &outputBuffer, flag: flag)
+
+        // Make sure all of inputBuffer was read, and outputBuffer isn't empty
+        precondition(inputBuffer.readableBytes == 0)
+        precondition(outputBuffer.readableBytes > 0)
+
+        // Remove the 0x78 0x9C zlib header added by zlib
+        _ = outputBuffer.readBytes(length: 2)
+        outputBuffer.discardReadBytes()
+
+        // Ignore the 0, 0, 0xff, 0xff trailer added by zlib
+        if dropFourTrailingOctets {
+            outputBuffer = outputBuffer.getSlice(at: 0, length: outputBuffer.readableBytes-4) ?? outputBuffer
+        }
+
+        return outputBuffer
+    }
+}
+
+// This code is borrowed from swift-nio: https://github.com/apple/swift-nio/blob/master/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+private extension z_stream {
+    // Executes deflate from one buffer to another buffer. The advantage of this method is that it
+    // will ensure that the stream is "safe" after each call (that is, that the stream does not have
+    // pointers to byte buffers any longer).
+    mutating func _deflate(from: inout ByteBuffer, to: inout ByteBuffer, flag: Int32) {
+        defer {
+            // Per https://www.zlib.net/zlib_how.html
+            self.avail_in = 0
+            self.next_in = nil
+            self.avail_out = 0
+            self.next_out = nil
+        }
+
+        from.readWithUnsafeMutableReadableBytes { dataPtr in
+            let typedPtr = dataPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            let typedDataPtr = UnsafeMutableBufferPointer(start: typedPtr,
+                                                          count: dataPtr.count)
+
+            self.avail_in = UInt32(typedDataPtr.count)
+            self.next_in = typedDataPtr.baseAddress!
+
+            let rc = deflateToBuffer(buffer: &to, flag: flag)
+            precondition(rc == Z_OK || rc == Z_STREAM_END, "Deflate failed: \(rc)")
+
+            return typedDataPtr.count - Int(self.avail_in)
+        }
+    }
+
+    // A private function that sets the deflate target buffer and then calls deflate.
+    // This relies on having the input set by the previous caller: it will use whatever input was
+    // configured.
+    private mutating func deflateToBuffer(buffer: inout ByteBuffer, flag: Int32) -> Int32 {
+        var rc = Z_OK
+
+        buffer.writeWithUnsafeMutableBytes { outputPtr in
+            let typedOutputPtr = UnsafeMutableBufferPointer(start: outputPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                                                            count: outputPtr.count)
+            self.avail_out = UInt32(typedOutputPtr.count)
+            self.next_out = typedOutputPtr.baseAddress!
+            rc = deflate(&self, flag)
+            return typedOutputPtr.count - Int(self.avail_out)
+        }
+
+        return rc
+    }
+}

--- a/Sources/KituraWebSocket/PermessageDeflateDecompressor.swift
+++ b/Sources/KituraWebSocket/PermessageDeflateDecompressor.swift
@@ -1,0 +1,161 @@
+/*
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIO
+import CZlib
+import NIOWebSocket
+
+// Implementation of `PermessageDeflateDecompressor` a `ChannelInboundHandler` that intercepts incoming WebSocket frames, inflating the payload and
+// writing the new frames back to the channel, to be eventually received by WebSocketConnection.
+
+// Some parts of this code are derived from swift-nio: https://github.com/apple/swift-nio/blob/master/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+class PermessageDeflateDecompressor : ChannelInboundHandler {
+    typealias InboundIn = WebSocketFrame 
+    typealias InboundOut = WebSocketFrame
+
+    init(maxWindowBits: Int32 = 15, noContextTakeOver: Bool = false) {
+        self.maxWindowBits = maxWindowBits
+        self.noContextTakeOver = noContextTakeOver
+    }
+
+    var noContextTakeOver: Bool
+
+    // The zlib stream
+    private var stream: z_stream = z_stream()
+
+    // A buffer to accumulate payload across multiple frames
+    var payload: ByteBuffer?
+
+    // Is this a text or binary message? Continuation frames don't have this information.
+    private var messageType: WebSocketOpcode?
+
+    // The default LZ77 window size; 15
+    var maxWindowBits = MAX_WBITS
+
+    // PermessageDeflateDecompressor is a `ChannelInboundHandler`, this function gets called when the previous inbound handler fires a channel read event.
+    // Here, we intercept incoming compressed frames, decompress the payload across multiple continuation frame and write a fire a channel read event
+    // with the entire frame data decompressed.
+    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+        var frame = unwrapInboundIn(data)
+        // If this is a control frame, there's nothing to do.
+        guard frame.opcode == .text || frame.opcode == .binary || frame.opcode == .continuation else {
+            ctx.fireChannelRead(self.wrapInboundOut(frame))
+            return
+        }
+
+        // If this is a continuation frame, have the payload appended to `payload`, else set `payload` and store the messageType
+        var receivedPayload = frame.unmaskedData
+        if frame.opcode == .continuation {
+            self.payload?.write(buffer: &receivedPayload)
+        } else {
+            self.messageType = frame.opcode
+            self.payload = receivedPayload
+        }
+
+        // If the current frame isn't a final frame of a message or if `payload` still empty, there's nothing to do.
+        guard frame.fin, var inputBuffer = self.payload else { return }
+
+        // Append the trailer 0, 0, ff, ff before decompressing
+        inputBuffer.write(bytes: [0x00, 0x00, 0xff, 0xff])
+        var inflatedPayload = inflatePayload(in: inputBuffer, allocator: ctx.channel.allocator)
+
+        // Apply the WebSocket mask on the inflated payload
+        inflatedPayload.webSocketMask(frame.maskKey!)
+
+        // Create a new frame with the inflated payload and pass it on to the next inbound handler, mostly WebSocketConnection
+        let inflatedFrame = WebSocketFrame(fin: true, rsv1: false, opcode: self.messageType!, maskKey: frame.maskKey!, data: inflatedPayload)
+        ctx.fireChannelRead(self.wrapInboundOut(inflatedFrame))
+    }
+
+    func inflatePayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator) -> ByteBuffer {
+        // Initialize the inflater as per https://www.zlib.net/zlib_how.html
+        stream.zalloc = nil 
+        stream.zfree = nil 
+        stream.opaque = nil 
+        stream.avail_in = 0 
+        stream.next_in = nil 
+        let rc = inflateInit2_(&stream, -self.maxWindowBits, ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
+        precondition(rc == Z_OK, "Unexpected return from zlib init: \(rc)")
+
+        defer {
+            // Deinitialize before returning
+            inflateEnd(&stream)
+        }
+
+        // Inflate/decompress the payload
+        return decompressPayload(in: buffer, allocator: allocator, flag: Z_SYNC_FLUSH)
+    }
+
+    func decompressPayload(in buffer: ByteBuffer, allocator: ByteBufferAllocator, flag: Int32) -> ByteBuffer {
+        var inputBuffer = buffer
+        guard inputBuffer.readableBytes > 0 else {
+            // TODO: Log an error
+            return buffer
+        }
+        let payloadSize =  inputBuffer.readableBytes
+        var outputBuffer = allocator.buffer(capacity: 2) // starting with a small capacity hint
+
+        // Decompression may happen in steps, we'd need to continue calling inflate() until there's no available input
+        repeat {
+            var partialOutputBuffer = allocator.buffer(capacity: inputBuffer.readableBytes)
+            stream._inflate(from: &inputBuffer, to: &partialOutputBuffer, flag: flag)
+            // calculate the number of bytes processed
+            let processedBytes = payloadSize - Int(stream.avail_in)
+            // move the reader index
+            inputBuffer.moveReaderIndex(to: processedBytes)
+            // append partial output to the ouput buffer
+            outputBuffer.write(buffer: &partialOutputBuffer)
+        } while stream.avail_in > 0
+        return outputBuffer 
+    }
+}
+
+// This code is derived from swift-nio: https://github.com/apple/swift-nio/blob/master/Sources/NIOHTTP1/HTTPResponseCompressor.swift
+extension z_stream {
+    // Executes inflate from one buffer to another buffer.
+    mutating func _inflate(from: inout ByteBuffer, to: inout ByteBuffer, flag: Int32) {
+        from.readWithUnsafeMutableReadableBytes { dataPtr in
+            let typedPtr = dataPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            let typedDataPtr = UnsafeMutableBufferPointer(start: typedPtr, count: dataPtr.count)
+            self.avail_in = UInt32(typedDataPtr.count)
+            self.next_in = typedDataPtr.baseAddress!
+            let rc = inflateToBuffer(buffer: &to, flag: flag)
+            precondition(rc == Z_OK || rc == Z_STREAM_END, "Decompression failed: \(rc)")
+            if rc == Z_STREAM_END {
+                inflateEnd(&self)
+            }
+            return typedDataPtr.count - Int(self.avail_in)
+        }
+    }
+
+    // A private function that sets the inflate target buffer and then calls inflate.
+    // This relies on having the input set by the previous caller: it will use whatever input was
+    // configured.
+    private mutating func inflateToBuffer(buffer: inout ByteBuffer, flag: Int32) -> Int32 {
+        var rc = Z_OK
+
+        buffer.writeWithUnsafeMutableBytes { outputPtr in
+            let typedOutputPtr = UnsafeMutableBufferPointer(start: outputPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                                                            count: outputPtr.count)
+            
+            self.avail_out = UInt32(typedOutputPtr.count)
+            self.next_out = typedOutputPtr.baseAddress!
+            rc = inflate(&self, flag)
+            return typedOutputPtr.count - Int(self.avail_out)
+        }
+        return rc
+    }
+}

--- a/Sources/KituraWebSocket/WebSocketConnection.swift
+++ b/Sources/KituraWebSocket/WebSocketConnection.swift
@@ -312,7 +312,7 @@ extension WebSocketConnection {
         }
 
         let frame = WebSocketFrame(fin: true, opcode: opcode, data: data)
-        _ = ctx.writeAndFlush(self.wrapOutboundOut(frame))
+        ctx.writeAndFlush(self.wrapOutboundOut(frame), promise: nil)
     }
 
     func closeConnection(reason: WebSocketErrorCode?, description: String?, hard: Bool) {
@@ -327,7 +327,9 @@ extension WebSocketConnection {
          }
 
          let frame = WebSocketFrame(fin: true, opcode: .connectionClose, data: data)
-         ctx.writeAndFlush(self.wrapOutboundOut(frame)).whenComplete {
+         let promise = ctx.eventLoop.newPromise(of: Void.self)
+         ctx.writeAndFlush(self.wrapOutboundOut(frame), promise: promise)
+         promise.futureResult.whenComplete {
              if hard {
                  _ = ctx.close(mode: .output)
              }

--- a/Tests/KituraWebSocketTests/BasicTests.swift
+++ b/Tests/KituraWebSocketTests/BasicTests.swift
@@ -46,50 +46,64 @@ class BasicTests: KituraTest {
     func testBinaryLongMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest { expectation in
+        var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
+        let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
+        repeat {
+            binaryPayload.append(binaryPayload.bytes, length: binaryPayload.length)
+        } while binaryPayload.length < 100000
+        binaryPayload.append(&bytes, length: bytes.count)
 
-            var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
-            let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
-            repeat {
-                binaryPayload.append(binaryPayload.bytes, length: binaryPayload.length)
-            } while binaryPayload.length < 100000
-            binaryPayload.append(&bytes, length: bytes.count)
-
+        performServerTest (asyncTasks: { expectation in
             self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
                              expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
                              expectation: expectation)
-        }
+        }, { expectation in
+            self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                             expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                             expectation: expectation, compressed: true)
+        })
     }
 
     func testBinaryMediumMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest { expectation in
 
-            var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
-            let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
-            repeat {
-                binaryPayload.append(binaryPayload.bytes, length: binaryPayload.length)
-            } while binaryPayload.length < 1000
+        var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
+        let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
+        repeat {
+            binaryPayload.append(binaryPayload.bytes, length: binaryPayload.length)
+        } while binaryPayload.length < 1000
+
+        performServerTest (asyncTasks: { expectation in
 
             self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
                              expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
                              expectation: expectation)
-        }
+        }, { expectation in
+
+            self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                             expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                             expectation: expectation, compressed: true)
+        })
     }
 
     func testBinaryShortMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest { expectation in
+        var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
+        let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
 
-            var bytes = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
-            let binaryPayload = NSMutableData(bytes: &bytes, length: bytes.count)
+        performServerTest (asyncTasks: { expectation in
 
             self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
                              expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
                              expectation: expectation)
-        }
+        }, { expectation in
+
+            self.performTest(framesToSend: [(true, self.opcodeBinary, binaryPayload)],
+                             expectedFrames: [(true, self.opcodeBinary, binaryPayload)],
+                             expectation: expectation, compressed: true)
+        })
     }
 
     func testGracefullClose() {
@@ -179,48 +193,63 @@ class BasicTests: KituraTest {
     func testTextLongMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest { expectation in
+        var text = "Testing, testing 1, 2, 3."
+        repeat {
+            text += " " + text
+        } while text.count < 100000
+        let textPayload = self.payload(text: text)
 
-            var text = "Testing, testing 1, 2, 3."
-            repeat {
-                text += " " + text
-            } while text.count < 100000
-            let textPayload = self.payload(text: text)
+        performServerTest (asyncTasks: { expectation in
 
             self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
                              expectedFrames: [(true, self.opcodeText, textPayload)],
                              expectation: expectation)
-        }
+        }, { expectation in
+
+            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                             expectedFrames: [(true, self.opcodeText, textPayload)],
+                             expectation: expectation, compressed: true)
+        })
     }
 
     func testTextMediumMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest { expectation in
+        var text = ""
+        repeat {
+            text += "Testing, testing 1,2,3. "
+        } while text.count < 1000
+        let textPayload = self.payload(text: text)
 
-            var text = ""
-            repeat {
-                text += "Testing, testing 1,2,3. "
-            } while text.count < 1000
-            let textPayload = self.payload(text: text)
+        performServerTest(asyncTasks: { expectation in
 
             self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
                              expectedFrames: [(true, self.opcodeText, textPayload)],
                              expectation: expectation)
-        }
+        }, { expectation in
+
+            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                             expectedFrames: [(true, self.opcodeText, textPayload)],
+                             expectation: expectation, compressed: true)
+        })
     }
 
     func testTextShortMessage() {
         register(closeReason: .noReasonCodeSent)
 
-        performServerTest { expectation in
+        let textPayload = self.payload(text: "Testing, testing 1,2,3")
 
-            let textPayload = self.payload(text: "Testing, testing 1,2,3")
+        performServerTest(asyncTasks: { expectation in
 
             self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
                              expectedFrames: [(true, self.opcodeText, textPayload)],
                              expectation: expectation)
-        }
+        }, { expectation in
+
+            self.performTest(framesToSend: [(true, self.opcodeText, textPayload)],
+                             expectedFrames: [(true, self.opcodeText, textPayload)],
+                             expectation: expectation, compressed: true)
+        })
     }
 
     func testUserDefinedCloseCode() {

--- a/Tests/KituraWebSocketTests/InflaterDeflaterTests.swift
+++ b/Tests/KituraWebSocketTests/InflaterDeflaterTests.swift
@@ -1,0 +1,85 @@
+/**
+ * Copyright IBM Corporation 2019
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+import Foundation
+import NIO
+import CZlib
+
+@testable import KituraWebSocket
+
+class InflaterDeflaterTests: KituraTest {
+
+    static var allTests: [(String, (InflaterDeflaterTests) -> () throws -> Void)] {
+        return [
+            ("testDeflateAndInflateWithString", testDeflateAndInflateWithString),
+            ("testDeflateAndInflateWithBytes", testDeflateAndInflateWithBytes),
+        ]
+    }
+
+    func testDeflateAndInflateWithString() {
+        testWithString("a")
+        testWithString("xy")
+        testWithString("abc")
+        testWithString("abcd")
+        testWithString("0000")
+        testWithString("skfjsdlkjfldkjioroi32j423kljl213kj4lk32j4lk2j4kl32j4lk32j4lk3242")
+        testWithString("0000000000000000000000000000000000000000000000000000")
+        testWithString("1nkp12p032nn1l1o1knfk;0i0nju]ijijkjkj1121212100000000000000000fsfefdf12121212121fdgfgfgfgfgf")
+        testWithString("abcdefghijklmnopqrstuvwxyz0123456789")
+        testWithString(String(repeating: "quick brown fox jumps over the lazy dog", count: 100))
+    }
+
+    func testDeflateAndInflateWithBytes() {
+         let bytes: [UInt8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e]
+         var buffer = ByteBufferAllocator().buffer(capacity: 1)
+         var count = 0
+         repeat {
+             buffer.write(bytes: bytes)
+             count += 1
+         } while count < 100000
+
+         //deflate
+         let deflater = PermessageDeflateCompressor()
+         let deflatedBuffer = deflater.deflatePayload(in: buffer, allocator: ByteBufferAllocator())
+
+         //inflate
+         let inflater = PermessageDeflateDecompressor()
+         let inflatedBuffer = inflater.inflatePayload(in: deflatedBuffer, allocator: ByteBufferAllocator())
+
+         //test
+         XCTAssertEqual(buffer, inflatedBuffer)
+    }
+
+
+    func testWithString(_ input: String) {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1)
+        buffer.write(string: input)
+
+        //deflate
+        let deflater = PermessageDeflateCompressor()
+        let deflatedBuffer = deflater.deflatePayload(in: buffer, allocator: ByteBufferAllocator())
+
+        //inflate
+        let inflater = PermessageDeflateDecompressor()
+        var inflatedBuffer = inflater.inflatePayload(in: deflatedBuffer, allocator: ByteBufferAllocator())
+        let output = inflatedBuffer.readString(length: inflatedBuffer.readableBytes)
+ 
+        //test   
+        XCTAssertEqual(output, input)
+    }
+         
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -62,5 +62,6 @@ XCTMain([
     testCase(BasicTests.allTests.shuffled()),
     testCase(ComplexTests.allTests.shuffled()),
     testCase(ProtocolErrorTests.allTests.shuffled()),
-    testCase(UpgradeErrors.allTests.shuffled())
+    testCase(UpgradeErrors.allTests.shuffled()),
+    testCase(InflaterDeflaterTests.allTests.shuffled())
 ].shuffled())


### PR DESCRIPTION
An initial implementation of websocket compression using `permessage-deflate` using zlib. 

Some TODOs:
- [x] Add tests
- [x] Modify the Package.swift after related changes are merged and tagged in Kitura-NIO
- [x] Fix an intermittent "Leaking Promise" failure
- [x] Add comments to the new code
- [x] Use `IBM-Swift/CZlib` instead of the `CZLib` module added in this pull request