### PR TITLE
[nio]autobahn: fixes for compression tests

### DIFF
--- a/Sources/KituraWebSocket/PermessageDeflate.swift
+++ b/Sources/KituraWebSocket/PermessageDeflate.swift
@@ -76,10 +76,6 @@ class PermessageDeflate: WebSocketProtocolExtension {
         guard header.hasPrefix("permessage-deflate") else { return response }
 
         for parameter in header.components(separatedBy: "; ") {
-            if parameter.hasPrefix("client_max_window_bits") {
-                response.append("; client_max_window_bits")
-            }
-
             if parameter == "client_no_context_takeover" {
                 response.append("; \(parameter)")
             }

--- a/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
+++ b/Sources/KituraWebSocket/PermessageDeflateCompressor.swift
@@ -68,7 +68,7 @@ class PermessageDeflateCompressor : ChannelOutboundHandler {
         guard frame.fin, let payload = payload else { return }
 
         // Compress the payload
-        let deflatedPayload = deflatePayload(in: payload, allocator: ctx.channel.allocator)
+        let deflatedPayload = deflatePayload(in: payload, allocator: ctx.channel.allocator, dropFourTrailingOctets: true)
 
         // Create a new frame with the compressed payload, the rsv1 bit must be set to indicate compression
         let deflatedFrame = WebSocketFrame(fin: frame.fin, rsv1: true, opcode: self.messageType!, maskKey: frame.maskKey, data: deflatedPayload)


### PR DESCRIPTION
This commit makes two changes. Firstly, client_max_window bits must not be returned in the negotiation response. Secondly, after deflating the payload, the last four octets need to be dropped.