### PR TITLE
[websocket-nio] make Cryptor only a test dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,9 +44,9 @@ let package = Package(
         ),
         .target(
             name: "KituraWebSocket",
-            dependencies: ["CZlib", "KituraNet", "Cryptor"]),
+            dependencies: ["CZlib", "KituraNet"]),
         .testTarget(
             name: "KituraWebSocketTests",
-            dependencies: ["KituraWebSocket"])
+            dependencies: ["KituraWebSocket", "Cryptor"])
     ]
 )

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -38,9 +38,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "KituraWebSocket",
-            dependencies: ["CZlib", "KituraNet", "Cryptor"]),
+            dependencies: ["CZlib", "KituraNet"]),
         .testTarget(
             name: "KituraWebSocketTests",
-            dependencies: ["KituraWebSocket"])
+            dependencies: ["KituraWebSocket", "Cryptor"])
     ]
 )

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -38,9 +38,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "KituraWebSocket",
-            dependencies: ["CZlib", "KituraNet", "Cryptor"]),
+            dependencies: ["CZlib", "KituraNet"]),
         .testTarget(
             name: "KituraWebSocketTests",
-            dependencies: ["KituraWebSocket"])
+            dependencies: ["KituraWebSocket", "Cryptor"])
     ]
 )


### PR DESCRIPTION
Cryptor is used only in the Kitura-WebSocket tests in the client implementation. Moving it to the right dependency set.