### PR TITLE
Add Autobahn echo server with Dockerfile

### DIFF
--- a/Autobahn/.dockerignore
+++ b/Autobahn/.dockerignore
@@ -1,0 +1,6 @@
+.build
+Package.resolved
+run.sh
+Dockerfile
+reports
+config

--- a/Autobahn/.gitignore
+++ b/Autobahn/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/Autobahn/Dockerfile
+++ b/Autobahn/Dockerfile
@@ -1,0 +1,11 @@
+FROM swift:5.1
+
+RUN apt-get update && apt-get install -y libssl-dev libcurl4-openssl-dev libz-dev
+
+COPY . /WebSocketEchoServer
+
+WORKDIR /WebSocketEchoServer
+
+RUN swift build
+
+CMD .build/debug/WebSocketEchoServer

--- a/Autobahn/Package.swift
+++ b/Autobahn/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.1
+import PackageDescription
+
+let package = Package(
+    name: "WebSocketEchoServer",
+    dependencies: [
+         .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.8.0"),
+         .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.7.0"),
+         .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "2.0.0")
+    ],
+    targets: [
+    .target(
+        name: "WebSocketEchoServer",
+        dependencies: ["Kitura", "HeliumLogger", "Kitura-WebSocket"]),
+    ]
+)

--- a/Autobahn/README.md
+++ b/Autobahn/README.md
@@ -1,0 +1,3 @@
+# Autobahn
+
+A description of this package.

--- a/Autobahn/Sources/WebSocketEchoServer/EchoService.swift
+++ b/Autobahn/Sources/WebSocketEchoServer/EchoService.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+import KituraWebSocket
+import LoggerAPI
+
+class EchoService: WebSocketService {
+
+    public func connected(connection: WebSocketConnection) {}
+
+    public func disconnected(connection: WebSocketConnection, reason: WebSocketCloseReasonCode) {}
+
+    public func received(message: Data, from: WebSocketConnection) {
+        from.send(message: message)
+    }
+
+    public func received(message: String, from: WebSocketConnection) {
+        let msgLength = message.utf8.count
+        if msgLength > 100 {
+            Log.info("Got message of length \(msgLength)... sending it back")
+        } else {
+            Log.info("Got message '\(message)'... sending it back")
+        }
+        from.send(message: message)
+    }
+}

--- a/Autobahn/Sources/WebSocketEchoServer/main.swift
+++ b/Autobahn/Sources/WebSocketEchoServer/main.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Kitura
+import KituraWebSocket
+import HeliumLogger
+
+// Using an implementation for a Logger
+HeliumLogger.use(.info)
+
+let router = Router()
+
+WebSocket.register(service: EchoService(), onPath: "/")
+
+let port = 9001
+
+Kitura.addHTTPServer(onPort: port, with: router)
+Kitura.run()

--- a/Autobahn/config/fuzzingclient.json
+++ b/Autobahn/config/fuzzingclient.json
@@ -1,0 +1,11 @@
+{
+   "outdir": "./reports/servers",
+   "servers": [
+      {
+        "url": "ws://wsserver:9001"
+      }
+   ],
+   "cases": ["*"],
+   "exclude-cases": [],
+   "exclude-agent-cases": {}
+}

--- a/Autobahn/run.sh
+++ b/Autobahn/run.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Convenience script to build and run a Kitura-WebSocket echo server in a Docker container,
+# and then to run the autobahn test suite Docker container against it.
+#
+# Once complete, the autobahn report (HTML format) will be opened.
+#
+
+# Create network
+docker network rm autobahn
+docker network create --driver bridge autobahn
+
+# Build server
+docker build -t wsserver .
+
+# Execute server
+docker container rm wsserver
+docker run -d --network autobahn --name wsserver wsserver
+
+# Execute client
+docker run -it --rm \
+    -v ${PWD}/config:/config \
+    -v ${PWD}/reports:/reports \
+    --name fuzzingclient \
+    --network autobahn \
+    crossbario/autobahn-testsuite \
+    wstest -m fuzzingclient -s config/fuzzingclient.json
+
+# Stop server
+docker container stop wsserver
+
+# Check out test report!
+open ./reports/servers/index.html

--- a/AutobahnTests.md
+++ b/AutobahnTests.md
@@ -2,6 +2,12 @@
 
 This document will take you through the steps to test Kitura-Websockets using [autobahn-testsuite](https://github.com/crossbario/autobahn-testsuite).
 
+### Convenience (ready-to-run) Docker implementation
+
+For convenience, a project is provided in `Autobahn/` that implements the code below.
+
+A script `Autobahn/run.sh` is included that will build this within a Docker container, run the container, and then run the autobahn test suite (in client mode) against this server.
+
 ### Creating a EchoServer
 These tests are run against a WebSocket EchoServer so we must first set one up.
 


### PR DESCRIPTION
While testing Kitura-WebSocket, I wanted to run the Autobahn tests against my changes.  The existing guide in `AutobahnTests.md` is helpful, but it's a pain to have to install all the dependencies for the client, deal with versions of Python, missing macOS headers and so on.

I found that there's an autobahn docker image (https://github.com/crossbario/autobahn-testsuite/tree/master/docker) that we can use for the client.  And we can do everything within Docker if we dockerize the echo server and run both on a network.

To that end, I've created an `Autobahn` subproject containing a Dockerfile and a `run.sh` which wil build the server into a `wsserver` image, run that as a container on a Docker network called `autobahn`, and then run the autobahn client (on the same network) targetting `wsserver:9001`.  At the end of the run, it'll open the HTML report that the client generates.